### PR TITLE
feat(security): refresh rotation+revocation, security headers, error scrub

### DIFF
--- a/docs/ENTERPRISE_SECURITY.md
+++ b/docs/ENTERPRISE_SECURITY.md
@@ -137,6 +137,30 @@ plus a database cross-check; HS256/none are rejected.
 > This also fixes a latent multi-replica bug where a per-process random secret
 > made tokens unverifiable across manager replicas/restarts.
 
+### Refresh-token rotation and revocation
+
+Refresh tokens are **single-use**: every call to `/api/v1/auth/refresh` revokes
+the presented token (by its `jti`) and issues a new access + refresh pair —
+reuse of a rotated token returns 401, which also surfaces token theft (a stolen
+token dies the moment either party refreshes). Logout (`/api/v1/auth/logout`
+with the `refreshToken` in the body) revokes the refresh token server-side, so
+it can no longer mint access tokens; the 15-minute access token simply ages
+out. Revocations live in the `revoked_token` denylist (Alembic `007`); rows for
+already-expired tokens are purged opportunistically.
+
+> **Upgrade note:** refresh tokens minted before `v2.1.x` rotation carry no
+> `jti` and are no longer accepted — users re-login once after upgrade.
+
+### API response hygiene
+
+- **Security headers on every response** (including errors): `X-Content-Type-
+  Options: nosniff`, `X-Frame-Options: DENY`, `Content-Security-Policy:
+  default-src 'none'; frame-ancestors 'none'`, `Referrer-Policy: no-referrer`,
+  and HSTS (`max-age=31536000; includeSubDomains`).
+- **No internal detail in error responses** — exception text (paths, DB
+  errors) is logged server-side with full tracebacks; clients receive generic
+  messages only.
+
 ### Scope-based authorization (roles are scope bundles)
 
 Authorization decisions are made on **scopes only** — never role names. A user's

--- a/manager/backend/alembic/versions/007_revoked_token.py
+++ b/manager/backend/alembic/versions/007_revoked_token.py
@@ -1,0 +1,34 @@
+"""Add revoked_token table — refresh-token rotation + logout revocation.
+
+Revision ID: 007_revoked_token
+Revises: 006_mtls_certificates
+"""
+from alembic import op
+from sqlalchemy import (
+    Column, DateTime, ForeignKey, Index, Integer, String, func
+)
+
+revision = "007_revoked_token"
+down_revision = "006_mtls_certificates"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add refresh-token revocation denylist."""
+    op.create_table(
+        'revoked_token',
+        Column('id', Integer, primary_key=True, autoincrement=True),
+        Column('jti', String(36), nullable=False, unique=True, index=True),
+        Column('user_id', Integer, ForeignKey('auth_user.id', ondelete='CASCADE')),
+        Column('reason', String(50)),
+        Column('revoked_at', DateTime, nullable=False, server_default=func.now()),
+        Column('expires_at', DateTime, nullable=False),
+    )
+    op.create_index('idx_revoked_token_expires', 'revoked_token', ['expires_at'])
+
+
+def downgrade() -> None:
+    """Remove refresh-token revocation denylist."""
+    op.drop_index('idx_revoked_token_expires', table_name='revoked_token')
+    op.drop_table('revoked_token')

--- a/manager/backend/app/__init__.py
+++ b/manager/backend/app/__init__.py
@@ -30,6 +30,24 @@ def create_app(config_class: type = Config) -> Flask:
         # Empty allowlist = deny cross-origin
         CORS(app, resources={r"/api/*": {"origins": []}})
 
+    # Security headers on every response. This is a JSON API: a restrictive
+    # CSP + nosniff blocks it from being abused as a script/style source, and
+    # frame-ancestors/X-Frame-Options prevent clickjacking via framed JSON.
+    @app.after_request
+    def set_security_headers(response):
+        response.headers.setdefault('X-Content-Type-Options', 'nosniff')
+        response.headers.setdefault('X-Frame-Options', 'DENY')
+        response.headers.setdefault(
+            'Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'"
+        )
+        response.headers.setdefault('Referrer-Policy', 'no-referrer')
+        # HSTS is only meaningful over TLS; browsers ignore it on plain HTTP,
+        # so setting it unconditionally is safe (TLS terminates at ingress).
+        response.headers.setdefault(
+            'Strict-Transport-Security', 'max-age=31536000; includeSubDomains'
+        )
+        return response
+
     # Rate limiting via penguin-limiter
     from penguin_limiter import FlaskRateLimiter, MemoryStorage, RateLimitConfig
 

--- a/manager/backend/app/blueprints/auth.py
+++ b/manager/backend/app/blueprints/auth.py
@@ -71,7 +71,11 @@ def login():
 @validate_json('refreshToken')
 def refresh():
     """
-    Refresh access token using refresh token.
+    Refresh (rotate) tokens using a refresh token.
+
+    The presented refresh token is single-use: it is revoked and a new
+    access + refresh token pair is issued. Reusing a rotated or revoked
+    refresh token returns 401.
 
     Request:
         {
@@ -80,19 +84,20 @@ def refresh():
 
     Response:
         {
-            "accessToken": "..."
+            "accessToken": "...",
+            "refreshToken": "..."
         }
     """
     data = request.get_json()
     refresh_token = data['refreshToken']
 
-    # Generate new access token
-    access_token = AuthService.refresh_access_token(refresh_token)
-    if not access_token:
+    tokens = AuthService.refresh_access_token(refresh_token)
+    if not tokens:
         return jsonify({'error': 'Invalid or expired refresh token'}), 401
 
     return jsonify({
-        'accessToken': access_token
+        'accessToken': tokens['access_token'],
+        'refreshToken': tokens['refresh_token']
     }), 200
 
 
@@ -101,15 +106,26 @@ def refresh():
 @audit_log('user_logout')
 def logout():
     """
-    Logout user (client-side token removal).
+    Logout user: revoke the refresh token server-side.
+
+    Request (optional body):
+        {
+            "refreshToken": "..."
+        }
+
+    The access token (15 min) simply ages out; the long-lived refresh token
+    is revoked here so it cannot mint new access tokens after logout.
 
     Response:
         {
             "message": "Logged out successfully"
         }
     """
-    # In stateless JWT, logout is handled client-side
-    # Can implement token blacklist here if needed
+    data = request.get_json(silent=True) or {}
+    refresh_token = data.get('refreshToken')
+    if refresh_token:
+        AuthService.revoke_refresh_token(refresh_token, reason='logout')
+
     return jsonify({
         'message': 'Logged out successfully'
     }), 200

--- a/manager/backend/app/blueprints/client_config.py
+++ b/manager/backend/app/blueprints/client_config.py
@@ -8,6 +8,7 @@ from functools import wraps
 from typing import Optional
 from flask import Blueprint, request, jsonify, current_app
 from app.middleware.auth import token_required
+from app.utils.responses import internal_error
 
 client_config_bp = Blueprint('client_config', __name__)
 
@@ -95,7 +96,7 @@ def create_domain():
             return jsonify(result), 400
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/domains/<int:domain_id>/jwt-rollover',
@@ -132,7 +133,7 @@ def rollover_jwt(domain_id: int):
             return jsonify(result), 404
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/domains/<int:domain_id>/configs',
@@ -193,7 +194,7 @@ def create_config(domain_id: int):
             return jsonify(result), 400
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/configs/<int:config_id>',
@@ -246,7 +247,7 @@ def update_config(config_id: int):
             return jsonify(result), 400
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/register', methods=['POST'])
@@ -301,7 +302,7 @@ def register_client():
             return jsonify(result), 400
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/pull', methods=['POST'])
@@ -352,7 +353,7 @@ def pull_config():
             return jsonify(result), 404
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/assign', methods=['POST'])
@@ -399,7 +400,7 @@ def assign_config():
             return jsonify(result), 404
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/domains/<int:domain_id>/clients',
@@ -432,7 +433,7 @@ def get_domain_clients(domain_id: int):
         clients = client_config_mgr.get_domain_clients(domain_id)
         return jsonify({'clients': clients}), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)
 
 
 @client_config_bp.route('/api/v1/client-config/stats', methods=['GET'])
@@ -460,4 +461,4 @@ def get_stats():
         stats = client_config_mgr.get_client_stats()
         return jsonify(stats), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return internal_error(e)

--- a/manager/backend/app/middleware/auth.py
+++ b/manager/backend/app/middleware/auth.py
@@ -152,7 +152,9 @@ def server_token_required(f):
             return f(*args, **kwargs)
 
         except Exception as e:
-            return jsonify({'error': f'Token validation failed: {str(e)}'}), 401
+            # Log the detail; never echo internal exception text to clients.
+            logger.warning("Server token validation failed: %s", e)
+            return jsonify({'error': 'Token validation failed'}), 401
 
     return decorated
 

--- a/manager/backend/app/schema.py
+++ b/manager/backend/app/schema.py
@@ -565,3 +565,19 @@ mtls_revocation = Table(
     Column("created_at", DateTime, nullable=False, server_default=func.now()),
 )
 Index("idx_mtls_revocation_serial", mtls_revocation.c.serial_number)
+
+# ── Refresh-token revocation (rotation + logout) ─────────────────────────────
+
+revoked_token = Table(
+    "revoked_token",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("jti", String(36), nullable=False, unique=True, index=True),
+    Column("user_id", Integer, ForeignKey("auth_user.id", ondelete="CASCADE")),
+    Column("reason", String(50)),  # 'rotated' | 'logout' | 'admin'
+    Column("revoked_at", DateTime, nullable=False, server_default=func.now()),
+    # Denylist entries only matter until the token would expire anyway;
+    # expired rows are purged opportunistically on new revocations.
+    Column("expires_at", DateTime, nullable=False),
+)
+Index("idx_revoked_token_expires", revoked_token.c.expires_at)

--- a/manager/backend/app/services/auth_service.py
+++ b/manager/backend/app/services/auth_service.py
@@ -3,6 +3,7 @@ Authentication service for Squawk DNS Manager.
 Handles JWT generation (asymmetric ES256/RS256), token refresh, and password hashing.
 """
 
+import uuid
 import jwt
 import bcrypt
 from datetime import datetime, timedelta
@@ -80,6 +81,8 @@ class AuthService:
             'tenant': tenant,
             'user_id': user_id,
             'type': 'refresh',
+            # Unique token id enables one-time-use rotation and revocation.
+            'jti': str(uuid.uuid4()),
             'exp': datetime.utcnow() + current_app.config['JWT_REFRESH_TOKEN_EXPIRES'],
             'iat': datetime.utcnow()
         }
@@ -185,18 +188,68 @@ class AuthService:
         }
 
     @staticmethod
-    def refresh_access_token(refresh_token: str) -> Optional[str]:
+    def _revoke_jti(jti: str, user_id: Optional[int], expires_at: datetime,
+                    reason: str) -> None:
+        """Add a refresh-token jti to the revocation denylist.
+
+        Also purges denylist rows whose tokens have already expired (they can
+        never be presented again), keeping the table small.
         """
-        Generate new access token from refresh token.
+        db = current_app.db
+        now = datetime.utcnow()
+        db(db.revoked_token.expires_at < now).delete()
+        # Idempotent: a jti already on the denylist stays revoked.
+        if not db(db.revoked_token.jti == jti).count():
+            db.revoked_token.insert(
+                jti=jti, user_id=user_id, reason=reason, expires_at=expires_at
+            )
+        db.commit()
 
-        Args:
-            refresh_token: Valid refresh token
+    @staticmethod
+    def is_refresh_token_revoked(jti: str) -> bool:
+        """True if the refresh-token jti has been revoked (rotation/logout)."""
+        db = current_app.db
+        return bool(db(db.revoked_token.jti == jti).count())
 
-        Returns:
-            New access token if valid, None otherwise
+    @staticmethod
+    def revoke_refresh_token(refresh_token: str, reason: str = 'logout') -> bool:
+        """Revoke a refresh token (e.g. on logout). Returns True if revoked.
+
+        Invalid/expired/legacy (no-jti) tokens are ignored — they can't be
+        used to mint access tokens anyway.
         """
         payload = AuthService.decode_token(refresh_token)
         if not payload or payload.get('type') != 'refresh':
+            return False
+        jti = payload.get('jti')
+        if not jti:
+            return False
+        expires_at = datetime.utcfromtimestamp(payload['exp'])
+        AuthService._revoke_jti(jti, payload.get('user_id'), expires_at, reason)
+        return True
+
+    @staticmethod
+    def refresh_access_token(refresh_token: str) -> Optional[Dict[str, str]]:
+        """
+        Rotate a refresh token: validate, check revocation, then issue a new
+        access token AND a new refresh token, revoking the presented one
+        (one-time use). Reuse of a rotated/revoked token fails.
+
+        Args:
+            refresh_token: Valid, unrevoked refresh token
+
+        Returns:
+            {'access_token': ..., 'refresh_token': ...} if valid, None otherwise
+        """
+        payload = AuthService.decode_token(refresh_token)
+        if not payload or payload.get('type') != 'refresh':
+            return None
+
+        # Fail closed: rotation requires a jti. Legacy jti-less refresh tokens
+        # cannot be revoked, so they are no longer accepted (forces one
+        # re-login after upgrade).
+        jti = payload.get('jti')
+        if not jti or AuthService.is_refresh_token_revoked(jti):
             return None
 
         db = current_app.db
@@ -213,9 +266,16 @@ class AuthService:
         for membership in memberships:
             team_roles[membership.team_id] = membership.role
 
-        return AuthService.create_access_token(
-            user.id, user.username, user.global_role, team_roles
-        )
+        # Rotate: the presented token is single-use.
+        expires_at = datetime.utcfromtimestamp(payload['exp'])
+        AuthService._revoke_jti(jti, user.id, expires_at, reason='rotated')
+
+        return {
+            'access_token': AuthService.create_access_token(
+                user.id, user.username, user.global_role, team_roles
+            ),
+            'refresh_token': AuthService.create_refresh_token(user.id),
+        }
 
     @staticmethod
     def validate_dns_token(token: str, domain: Optional[str] = None) -> Dict:

--- a/manager/backend/app/utils/decorators.py
+++ b/manager/backend/app/utils/decorators.py
@@ -182,12 +182,12 @@ def handle_db_errors(f):
         try:
             return f(*args, **kwargs)
         except Exception as e:
-            logger.error(f"Database error in {f.__name__}: {str(e)}")
+            # Log detail server-side; never echo exception text to clients.
+            logger.exception(f"Database error in {f.__name__}: {str(e)}")
             db = current_app.db
             db.rollback()
             return jsonify({
-                'error': 'Database operation failed',
-                'message': str(e)
+                'error': 'Database operation failed'
             }), 500
     return decorated_function
 

--- a/manager/backend/app/utils/responses.py
+++ b/manager/backend/app/utils/responses.py
@@ -1,0 +1,28 @@
+"""Shared API response helpers.
+
+Centralizes the error-response contract so internal exception detail
+(paths, DB errors, library messages) is logged server-side and never
+returned to clients.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+from flask import jsonify, request
+
+logger = logging.getLogger(__name__)
+
+
+def internal_error(exc: Exception, message: str = "Internal server error") -> Tuple:
+    """Log the exception with full detail; return a generic 500 to the client.
+
+    Usage:
+        except Exception as e:
+            return internal_error(e)
+    """
+    logger.exception(
+        "Unhandled error handling %s %s: %s", request.method, request.path, exc
+    )
+    return jsonify({"error": message}), 500

--- a/manager/backend/tests/test_auth_jwt.py
+++ b/manager/backend/tests/test_auth_jwt.py
@@ -246,7 +246,7 @@ class TestAlgorithmConfusionPrevention:
             result = AuthService.decode_token(hs256_token)
             assert result is None, "HS256 tokens must be rejected to prevent algorithm confusion"
 
-    def test_rs256_token_accepted_when_configured(self, app, jwt_keypair):
+    def test_rs256_token_accepted_when_configured(self, app, jwt_keypair, monkeypatch):
         """Test that RS256 token is accepted (fallback algorithm support)."""
         with app.app_context():
             # Generate RS256 keypair
@@ -266,7 +266,9 @@ class TestAlgorithmConfusionPrevention:
                 format=serialization.PublicFormat.SubjectPublicKeyInfo
             ).decode('utf-8')
 
-            app.config['JWT_PUBLIC_KEY'] = rs256_public_pem
+            # monkeypatch: the app fixture is session-scoped — a bare
+            # assignment would leak the RSA key into every later test.
+            monkeypatch.setitem(app.config, 'JWT_PUBLIC_KEY', rs256_public_pem)
 
             # Create RS256 token
             rs256_private_pem = rs256_key.private_bytes(

--- a/manager/backend/tests/test_refresh_rotation.py
+++ b/manager/backend/tests/test_refresh_rotation.py
@@ -1,0 +1,137 @@
+"""Tests for refresh-token rotation and revocation.
+
+Refresh tokens are single-use: /auth/refresh revokes the presented token and
+issues a new pair; reuse of a rotated or logged-out token fails. Legacy
+jti-less refresh tokens are rejected (they cannot be revoked).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import jwt
+import pytest
+
+from app.services.auth_service import AuthService
+
+
+@pytest.fixture
+def user_id(app):
+    """Insert an active test user and return its id."""
+    user = app.db.auth_user.insert(
+        username='rotate-user',
+        email='rotate@example.com',
+        password_hash='x',
+        global_role='Viewer',
+        active=True,
+    )
+    app.db.commit()
+    return user
+
+
+def test_refresh_token_carries_jti(app, jwt_keypair, user_id):
+    token = AuthService.create_refresh_token(user_id)
+    payload = jwt.decode(
+        token, jwt_keypair['public'], algorithms=['ES256'],
+        audience='squawk', issuer='squawk-manager',
+    )
+    assert payload['type'] == 'refresh'
+    assert payload.get('jti')  # non-empty unique id
+
+
+def test_refresh_rotates_and_blocks_reuse(app, user_id):
+    original = AuthService.create_refresh_token(user_id)
+
+    first = AuthService.refresh_access_token(original)
+    assert first is not None
+    assert first['access_token'] and first['refresh_token']
+    assert first['refresh_token'] != original
+
+    # The presented token was revoked by rotation — reuse must fail.
+    assert AuthService.refresh_access_token(original) is None
+
+    # The rotated (new) token still works.
+    second = AuthService.refresh_access_token(first['refresh_token'])
+    assert second is not None
+
+
+def test_logout_revocation_blocks_refresh(app, user_id):
+    token = AuthService.create_refresh_token(user_id)
+    assert AuthService.revoke_refresh_token(token, reason='logout') is True
+    assert AuthService.refresh_access_token(token) is None
+
+
+def test_legacy_jtiless_refresh_token_rejected(app, jwt_keypair, user_id):
+    """Refresh tokens minted before rotation (no jti) cannot be rotated."""
+    now = datetime.utcnow()
+    legacy = jwt.encode(
+        {
+            'sub': str(user_id), 'iss': 'squawk-manager', 'aud': 'squawk',
+            'tenant': 'default', 'user_id': user_id, 'type': 'refresh',
+            'exp': now + timedelta(days=7), 'iat': now,
+        },
+        jwt_keypair['private'], algorithm='ES256',
+    )
+    assert AuthService.refresh_access_token(legacy) is None
+
+
+def test_access_token_not_accepted_for_refresh(app, user_id):
+    access = AuthService.create_access_token(user_id, 'rotate-user', 'Viewer')
+    assert AuthService.refresh_access_token(access) is None
+
+
+def test_inactive_user_cannot_refresh(app, user_id):
+    token = AuthService.create_refresh_token(user_id)
+    app.db(app.db.auth_user.id == user_id).update(active=False)
+    app.db.commit()
+    assert AuthService.refresh_access_token(token) is None
+
+
+def test_expired_denylist_rows_are_purged(app, user_id):
+    """Rows for already-expired tokens are purged on the next revocation."""
+    db = app.db
+    db.revoked_token.insert(
+        jti='stale-jti', user_id=user_id, reason='rotated',
+        expires_at=datetime.utcnow() - timedelta(days=1),
+    )
+    db.commit()
+
+    token = AuthService.create_refresh_token(user_id)
+    AuthService.revoke_refresh_token(token, reason='logout')
+
+    assert db(db.revoked_token.jti == 'stale-jti').count() == 0
+
+
+def test_refresh_endpoint_rotation_flow(app, client, user_id):
+    original = AuthService.create_refresh_token(user_id)
+
+    resp = client.post('/api/v1/auth/refresh', json={'refreshToken': original})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['accessToken'] and body['refreshToken']
+
+    # Reuse of the original (rotated) token → 401.
+    resp2 = client.post('/api/v1/auth/refresh', json={'refreshToken': original})
+    assert resp2.status_code == 401
+
+    # The rotated token works.
+    resp3 = client.post(
+        '/api/v1/auth/refresh', json={'refreshToken': body['refreshToken']}
+    )
+    assert resp3.status_code == 200
+
+
+def test_logout_endpoint_revokes_refresh_token(app, client, user_id, jwt_token_factory):
+    refresh = AuthService.create_refresh_token(user_id)
+    access = jwt_token_factory(user_id=user_id)
+
+    resp = client.post(
+        '/api/v1/auth/logout',
+        json={'refreshToken': refresh},
+        headers={'Authorization': f'Bearer {access}'},
+    )
+    assert resp.status_code == 200
+
+    # The revoked refresh token can no longer mint access tokens.
+    resp2 = client.post('/api/v1/auth/refresh', json={'refreshToken': refresh})
+    assert resp2.status_code == 401

--- a/manager/backend/tests/test_schema.py
+++ b/manager/backend/tests/test_schema.py
@@ -29,6 +29,8 @@ def test_schema_creates_all_tables():
         "dns_group", "user_group_assignment", "dns_routing_zone", "group_zone_access",
         # mTLS certificate lifecycle (migration)
         "mtls_certificate", "mtls_revocation",
+        # refresh-token rotation/revocation
+        "revoked_token",
     }
     assert expected == tables
     engine.dispose()

--- a/manager/backend/tests/test_security_headers.py
+++ b/manager/backend/tests/test_security_headers.py
@@ -1,0 +1,30 @@
+"""Tests for security response headers and error-detail scrubbing."""
+
+from __future__ import annotations
+
+
+def test_security_headers_on_every_response(client):
+    """after_request must stamp security headers even on error responses."""
+    resp = client.get('/api/v1/auth/me')  # 401 without a token — still stamped
+    assert resp.headers['X-Content-Type-Options'] == 'nosniff'
+    assert resp.headers['X-Frame-Options'] == 'DENY'
+    assert resp.headers['Content-Security-Policy'] == (
+        "default-src 'none'; frame-ancestors 'none'"
+    )
+    assert resp.headers['Referrer-Policy'] == 'no-referrer'
+    assert resp.headers['Strict-Transport-Security'] == (
+        'max-age=31536000; includeSubDomains'
+    )
+
+
+def test_internal_error_scrubs_exception_detail(app):
+    """internal_error logs the detail but returns only a generic message."""
+    from app.utils.responses import internal_error
+
+    secret_detail = "sqlite3.OperationalError: /var/lib/secret/path is locked"
+    with app.test_request_context('/api/v1/anything'):
+        resp, status = internal_error(Exception(secret_detail))
+    assert status == 500
+    body = resp.get_json()
+    assert body == {'error': 'Internal server error'}
+    assert secret_detail not in resp.get_data(as_text=True)

--- a/manager/frontend/src/hooks/useAuth.ts
+++ b/manager/frontend/src/hooks/useAuth.ts
@@ -35,6 +35,14 @@ export const useAuth = create<AuthStore>((set) => ({
   },
 
   logout: () => {
+    // Best-effort server-side revocation of the refresh token; local state is
+    // cleared regardless so logout never blocks on the network.
+    const refreshToken = localStorage.getItem('refreshToken');
+    if (refreshToken) {
+      api.post('/api/v1/auth/logout', { refreshToken }).catch(() => {
+        console.log('[useAuth] Logout revocation failed { ignored: true }');
+      });
+    }
     localStorage.clear();
     set({ user: null, isAuthenticated: false, isLoading: false });
     window.location.href = '/login';

--- a/manager/frontend/src/services/api.ts
+++ b/manager/frontend/src/services/api.ts
@@ -36,8 +36,13 @@ api.interceptors.response.use(
           const response = await axios.post(`${api.defaults.baseURL}/api/v1/auth/refresh`, {
             refreshToken,
           });
-          const { accessToken } = response.data;
+          // Rotation: the server revokes the presented refresh token and
+          // issues a new pair — store both or the next refresh will 401.
+          const { accessToken, refreshToken: rotatedRefreshToken } = response.data;
           localStorage.setItem('accessToken', accessToken);
+          if (rotatedRefreshToken) {
+            localStorage.setItem('refreshToken', rotatedRefreshToken);
+          }
           originalRequest.headers.Authorization = `Bearer ${accessToken}`;
           return api.request(originalRequest);
         } catch (refreshError) {


### PR DESCRIPTION
Stacked on **#57**. Sixth branch in the chain (from the code-quality/security review).

## 1. Refresh-token rotation + revocation (real logout)
- Refresh tokens now carry a `jti`; `/auth/refresh` is **single-use** — the presented token is revoked and a new access+refresh pair issued. Reuse → 401, which also surfaces token theft.
- `/auth/logout` revokes the refresh token server-side (previously a no-op that left 7-day refresh tokens usable after logout).
- `revoked_token` denylist (schema + Alembic `007`); expired rows purged opportunistically. Legacy jti-less refresh tokens rejected (fail closed → one re-login after upgrade).
- Frontend updated in the same branch: `api.ts` stores the rotated refresh token; `useAuth` logout calls the API best-effort.

## 2. Security headers on every response
`after_request`: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `CSP default-src 'none'; frame-ancestors 'none'`, `Referrer-Policy: no-referrer`, HSTS.

## 3. Error-detail scrub (+ de-dup)
New `app/utils/responses.internal_error()` logs the exception with traceback and returns a generic 500 — replaces **9** identical `jsonify(str(e))` leaks in `client_config.py`; the middleware server-token error and `handle_db_errors` no longer echo exception text to clients.

## Also fixes
Pre-existing test pollution: `test_rs256_token_accepted_when_configured` overwrote `JWT_PUBLIC_KEY` on the session-scoped app fixture without restoring — surfaced by the new tests, fixed with `monkeypatch.setitem`.

## Tests
+12 (`test_refresh_rotation.py`, `test_security_headers.py`): rotation/reuse-blocked/logout/legacy-reject/inactive-user/purge + endpoint flows; headers stamped on error responses; scrub keeps detail out of the body. **Full manager suite: 142 passing.** flake8 clean. Documented in `docs/ENTERPRISE_SECURITY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement secure refresh-token rotation with server-side revocation, strengthen API response security, and clean up error handling and tests.

New Features:
- Make refresh tokens single-use with rotation that issues new access and refresh token pairs and rejects legacy jti-less tokens.
- Add server-side logout that revokes refresh tokens and wire the frontend to call the logout API and store rotated refresh tokens.

Bug Fixes:
- Prevent test-suite configuration leakage from RS256 JWT tests that previously modified global app config without restoring it.

Enhancements:
- Introduce a refresh-token revocation denylist table and migration with opportunistic purging of expired entries.
- Stamp consistent security headers, including CSP, HSTS, and clickjacking protections, on all API responses.
- Centralize internal error handling in a shared helper that logs exceptions with full detail while returning generic 500 responses.
- Scrub exception text from middleware and database error responses so internal details are never exposed to clients.

Documentation:
- Document refresh-token rotation and revocation semantics and API response hygiene measures in ENTERPRISE_SECURITY.md.

Tests:
- Add tests covering refresh-token rotation, revocation, legacy token rejection, endpoint flows, and denylist purging.
- Add tests verifying security headers on error responses and that internal error responses omit exception details.
- Fix JWT RS256 test pollution by using monkeypatch to avoid leaking configuration changes across tests.