### PR TITLE
refactor: de-dup JWT verification, DB lifecycle, and keypair generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ storage.db
 # Requirements files must always be tracked despite the broad *.txt ignore
 !requirements*.txt
 !**/requirements*.txt
+.worktrees/

--- a/dns-server/app/services/selective_router.py
+++ b/dns-server/app/services/selective_router.py
@@ -3,15 +3,9 @@ Selective DNS Routing Service
 Implements per-user/group zone access control.
 """
 import logging
-import jwt as pyjwt
-from jwt.exceptions import (
-    InvalidSignatureError, ExpiredSignatureError, DecodeError, InvalidTokenError,
-    InvalidAudienceError, InvalidIssuerError, MissingRequiredClaimError
-)
 from typing import Dict, List, Optional
-from app.config import (
-    JWT_PUBLIC_KEY, JWT_ISSUER, JWT_AUDIENCE
-)
+from app.config import JWT_PUBLIC_KEY
+from app.utils.jwt_verify import verify_squawk_jwt
 
 logger = logging.getLogger(__name__)
 
@@ -71,71 +65,47 @@ class SelectiveRouter:
             logger.debug(f"Access denied to {visibility} zone {zone['name']}: no token provided")
             return False
 
-        # Verify JWT signature and extract payload
-        try:
-            # Fail closed: JWT_PUBLIC_KEY must be configured for non-public zones
-            if not JWT_PUBLIC_KEY:
-                logger.error("JWT_PUBLIC_KEY not configured; denying access to non-public zone")
-                return False
-
-            # Verify with public key (ES256/RS256), require tenant claim
-            payload = pyjwt.decode(
-                token,
-                JWT_PUBLIC_KEY,
-                algorithms=['ES256', 'RS256'],
-                audience=JWT_AUDIENCE,
-                issuer=JWT_ISSUER,
-                options={'require': ['exp', 'iat', 'tenant']}
+        # Verify JWT via the shared verifier (ES256/RS256, iss/aud, required
+        # exp/iat/tenant, fail closed) — authorization stays here.
+        payload = verify_squawk_jwt(token, JWT_PUBLIC_KEY)
+        if payload is None:
+            logger.debug(
+                f"Access denied to {visibility} zone {zone['name']}: token verification failed"
             )
+            return False
 
-            # Fail closed: tenant claim must be present and non-empty
-            if not payload.get('tenant'):
-                logger.debug(f"Access denied: token missing or empty tenant claim")
-                return False
+        user_teams = payload.get('team_roles', {}).keys() if payload.get('team_roles') else []
 
-            user_teams = payload.get('team_roles', {}).keys() if payload.get('team_roles') else []
-            user_id = payload.get('user_id')
+        # Check if user's teams are in allowed teams
+        allowed_teams = zone.get('allowed_teams', [])
 
-            # Check if user's teams are in allowed teams
-            allowed_teams = zone.get('allowed_teams', [])
-
-            if visibility == 'internal':
-                # Internal: must be member of allowed teams
-                if not allowed_teams or any(team in allowed_teams for team in user_teams):
-                    return True
-                else:
-                    logger.debug(f"Access denied to internal zone {zone['name']}: user teams {user_teams} not in {allowed_teams}")
-                    return False
-
-            elif visibility == 'restricted':
-                # Restricted: must be in specific allowed teams
-                if any(team in allowed_teams for team in user_teams):
-                    return True
-                else:
-                    logger.debug(f"Access denied to restricted zone {zone['name']}: user teams {user_teams} not in {allowed_teams}")
-                    return False
-
-            elif visibility == 'private':
-                # Private: admin only (check for admin role in token)
-                is_admin = payload.get('role') == 'admin'
-                if is_admin:
-                    return True
-                else:
-                    logger.debug(f"Access denied to private zone {zone['name']}: user is not admin")
-                    return False
-
+        if visibility == 'internal':
+            # Internal: must be member of allowed teams
+            if not allowed_teams or any(team in allowed_teams for team in user_teams):
+                return True
             else:
-                # Unknown visibility, deny
+                logger.debug(f"Access denied to internal zone {zone['name']}: user teams {user_teams} not in {allowed_teams}")
                 return False
 
-        except (InvalidSignatureError, ExpiredSignatureError, DecodeError, InvalidTokenError) as e:
-            logger.warning(f"Invalid JWT token for zone access: {e}")
-            return False
-        except (InvalidAudienceError, InvalidIssuerError, MissingRequiredClaimError) as e:
-            logger.warning(f"JWT claim validation failed: {e}")
-            return False
-        except Exception as e:
-            logger.error(f"Token parsing error: {e}")
+        elif visibility == 'restricted':
+            # Restricted: must be in specific allowed teams
+            if any(team in allowed_teams for team in user_teams):
+                return True
+            else:
+                logger.debug(f"Access denied to restricted zone {zone['name']}: user teams {user_teams} not in {allowed_teams}")
+                return False
+
+        elif visibility == 'private':
+            # Private: admin only (check for admin role in token)
+            is_admin = payload.get('role') == 'admin'
+            if is_admin:
+                return True
+            else:
+                logger.debug(f"Access denied to private zone {zone['name']}: user is not admin")
+                return False
+
+        else:
+            # Unknown visibility, deny
             return False
 
     def get_zone_records(self, domain: str) -> Optional[List[Dict]]:

--- a/dns-server/app/utils/jwt_verify.py
+++ b/dns-server/app/utils/jwt_verify.py
@@ -1,0 +1,81 @@
+"""Shared Squawk JWT verification (single implementation for dns-server).
+
+Centralizes the ES256/RS256 verification contract used by every dns-server
+authorization path (selective_router, resilience):
+
+- asymmetric algorithms only (ES256/RS256) — HS256/none rejected, blocking
+  the public-key-as-HMAC algorithm-confusion attack
+- issuer + audience validated; exp/iat/tenant required
+- fail closed: no public key configured, or missing/empty tenant → reject
+
+Callers pass their configured public key and act on the returned payload;
+authorization (zone visibility/team rules) stays with the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import jwt as pyjwt
+from jwt.exceptions import (
+    DecodeError,
+    ExpiredSignatureError,
+    InvalidAudienceError,
+    InvalidIssuerError,
+    InvalidSignatureError,
+    InvalidTokenError,
+    MissingRequiredClaimError,
+)
+
+from app.config import JWT_AUDIENCE, JWT_ISSUER
+
+logger = logging.getLogger(__name__)
+
+
+def verify_squawk_jwt(token: str, public_key: Optional[str]) -> Optional[dict]:
+    """Verify a Squawk user JWT; return its payload or None (fail closed).
+
+    Args:
+        token: The presented bearer token.
+        public_key: PEM public key to verify with (caller's configured key).
+
+    Returns:
+        The verified payload dict, or None on any failure — unconfigured key,
+        bad signature/alg, expired, wrong iss/aud, missing/empty tenant.
+    """
+    if not public_key:
+        logger.error("JWT_PUBLIC_KEY not configured; denying access")
+        return None
+
+    if not token:
+        return None
+
+    try:
+        payload = pyjwt.decode(
+            token,
+            public_key,
+            algorithms=['ES256', 'RS256'],
+            audience=JWT_AUDIENCE,
+            issuer=JWT_ISSUER,
+            options={'require': ['exp', 'iat', 'tenant']},
+        )
+    except (InvalidSignatureError, ExpiredSignatureError, DecodeError) as e:
+        logger.warning(f"Invalid JWT token: {e}")
+        return None
+    except (InvalidAudienceError, InvalidIssuerError, MissingRequiredClaimError) as e:
+        logger.warning(f"JWT claim validation failed: {e}")
+        return None
+    except InvalidTokenError as e:
+        logger.warning(f"Invalid token: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Token validation error: {e}")
+        return None
+
+    # Fail closed: tenant claim must be present and non-empty
+    if not payload.get('tenant'):
+        logger.debug("Access denied: token missing or empty tenant claim")
+        return None
+
+    return payload

--- a/dns-server/app/utils/resilience.py
+++ b/dns-server/app/utils/resilience.py
@@ -5,14 +5,10 @@ Implements graceful degradation strategy: normal → cached → degraded.
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
-import jwt as pyjwt
-from jwt.exceptions import (
-    InvalidSignatureError, ExpiredSignatureError, DecodeError, InvalidTokenError,
-    InvalidAudienceError, InvalidIssuerError, MissingRequiredClaimError
-)
 
 from app.services.manager_client import ManagerClient
-from app.config import JWT_PUBLIC_KEY, JWT_ISSUER, JWT_AUDIENCE
+from app.config import JWT_PUBLIC_KEY
+from app.utils.jwt_verify import verify_squawk_jwt
 
 logger = logging.getLogger(__name__)
 
@@ -117,47 +113,22 @@ class ResilienceManager:
         if not token:
             return False
 
-        try:
-            # Fail closed: JWT_PUBLIC_KEY must be configured for non-public zones
-            if not JWT_PUBLIC_KEY:
-                logger.error("JWT_PUBLIC_KEY not configured; denying access to non-public zone")
-                return False
-
-            # Verify JWT signature and extract payload (ES256/RS256), require tenant
-            payload = pyjwt.decode(
-                token,
-                JWT_PUBLIC_KEY,
-                algorithms=['ES256', 'RS256'],
-                audience=JWT_AUDIENCE,
-                issuer=JWT_ISSUER,
-                options={'require': ['exp', 'iat', 'tenant']}
-            )
-
-            # Fail closed: tenant claim must be present and non-empty
-            if not payload.get('tenant'):
-                logger.debug(f"Access denied: token missing or empty tenant claim")
-                return False
-
-            user_teams = list(payload.get('team_roles', {}).keys()) if payload.get('team_roles') else []
-            allowed_teams = zone.get('allowed_teams', [])
-
-            # Check team membership
-            if not allowed_teams:
-                # No team restrictions
-                return True
-
-            # User must be in at least one allowed team
-            return any(team in allowed_teams for team in user_teams)
-
-        except (InvalidSignatureError, ExpiredSignatureError, DecodeError, InvalidTokenError) as e:
-            logger.warning(f"Invalid JWT token for zone access: {e}")
+        # Verify JWT via the shared verifier (ES256/RS256, iss/aud, required
+        # exp/iat/tenant, fail closed) — team authorization stays here.
+        payload = verify_squawk_jwt(token, JWT_PUBLIC_KEY)
+        if payload is None:
             return False
-        except (InvalidAudienceError, InvalidIssuerError, MissingRequiredClaimError) as e:
-            logger.warning(f"JWT claim validation failed: {e}")
-            return False
-        except Exception as e:
-            logger.error(f"Token validation error: {e}")
-            return False
+
+        user_teams = list(payload.get('team_roles', {}).keys()) if payload.get('team_roles') else []
+        allowed_teams = zone.get('allowed_teams', [])
+
+        # Check team membership
+        if not allowed_teams:
+            # No team restrictions
+            return True
+
+        # User must be in at least one allowed team
+        return any(team in allowed_teams for team in user_teams)
 
     def get_mode(self) -> str:
         """Get current operational mode."""

--- a/dns-server/tests_full_future/test_client_config_api.py
+++ b/dns-server/tests_full_future/test_client_config_api.py
@@ -14,10 +14,13 @@ from client_config_api import ClientConfigManager
 class TestClientConfigManager:
     
     @pytest.fixture
-    def config_manager(self, temp_db, test_jwt_secret):
-        """Create client config manager instance with test database"""
+    def config_manager(self, temp_db):
+        """Create client config manager instance with test database.
+
+        No keypair supplied -> ephemeral ES256 keypair (asymmetric signing).
+        """
         db_url = f"sqlite://{temp_db._uri[9:]}"  # Extract path from DAL URI
-        return ClientConfigManager(db_url, test_jwt_secret)
+        return ClientConfigManager(db_url)
     
     def test_create_deployment_domain(self, config_manager):
         """Test creating a new deployment domain"""
@@ -34,7 +37,10 @@ class TestClientConfigManager:
         
         # Verify JWT token is valid
         token = result['jwt_token']
-        decoded = jwt.decode(token, config_manager.jwt_secret, algorithms=['HS256'])
+        decoded = jwt.decode(
+            token, config_manager.public_key, algorithms=['ES256', 'RS256'],
+            audience=config_manager.audience, issuer=config_manager.issuer,
+        )
         assert decoded['domain'] == "test-domain"
         assert decoded['type'] == 'deployment_domain'
     
@@ -65,7 +71,10 @@ class TestClientConfigManager:
         
         # Verify new JWT is valid
         new_token = rollover_result['new_jwt']
-        decoded = jwt.decode(new_token, config_manager.jwt_secret, algorithms=['HS256'])
+        decoded = jwt.decode(
+            new_token, config_manager.public_key, algorithms=['ES256', 'RS256'],
+            audience=config_manager.audience, issuer=config_manager.issuer,
+        )
         assert decoded['domain'] == "rollover-test"
     
     def test_create_client_config(self, config_manager, mock_client_config):
@@ -353,16 +362,21 @@ class TestClientConfigManager:
         clients = config_manager.get_domain_clients(domain_result['id'])
         assert len(clients) == 0
     
-    def test_expired_jwt_rejection(self, config_manager, test_jwt_secret):
+    def test_expired_jwt_rejection(self, config_manager):
         """Test that expired JWT tokens are rejected"""
-        # Create expired JWT manually
+        # Create a genuinely expired ES256 domain token (signed with the
+        # manager's own private key so only expiry causes the rejection)
         expired_payload = {
             'domain': 'expired-test',
             'type': 'deployment_domain',
-            'issued_at': (datetime.now() - timedelta(days=2)).timestamp(),
-            'expires_at': (datetime.now() - timedelta(days=1)).timestamp()  # Expired
+            'iss': config_manager.issuer,
+            'aud': config_manager.audience,
+            'iat': datetime.now() - timedelta(days=2),
+            'exp': datetime.now() - timedelta(days=1),  # Expired
         }
-        expired_jwt = jwt.encode(expired_payload, test_jwt_secret, algorithm='HS256')
+        expired_jwt = jwt.encode(
+            expired_payload, config_manager.private_key, algorithm='ES256'
+        )
         
         # Try to register client with expired JWT
         register_result = config_manager.register_client(

--- a/manager/backend/app/config.py
+++ b/manager/backend/app/config.py
@@ -99,24 +99,10 @@ class DevelopmentConfig(Config):
         super().__init__()
         # If no keys configured, generate an ephemeral ES256 keypair in-memory
         if not self.JWT_PRIVATE_KEY or not self.JWT_PUBLIC_KEY:
-            from cryptography.hazmat.primitives.asymmetric import ec
-            from cryptography.hazmat.primitives import serialization
-            from cryptography.hazmat.backends import default_backend
-
-            private_key = ec.generate_private_key(
-                ec.SECP256R1(), default_backend()
+            from app.utils.crypto import generate_ephemeral_es256_keypair
+            self.JWT_PRIVATE_KEY, self.JWT_PUBLIC_KEY = (
+                generate_ephemeral_es256_keypair()
             )
-            self.JWT_PRIVATE_KEY = private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption()
-            ).decode('utf-8')
-
-            public_key = private_key.public_key()
-            self.JWT_PUBLIC_KEY = public_key.public_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PublicFormat.SubjectPublicKeyInfo
-            ).decode('utf-8')
 
 
 class ProductionConfig(Config):
@@ -156,24 +142,10 @@ class TestingConfig(Config):
         """Generate ephemeral ES256 keypair for testing."""
         super().__init__()
         # Always generate a fresh ES256 keypair for tests
-        from cryptography.hazmat.primitives.asymmetric import ec
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.backends import default_backend
-
-        private_key = ec.generate_private_key(
-            ec.SECP256R1(), default_backend()
+        from app.utils.crypto import generate_ephemeral_es256_keypair
+        self.JWT_PRIVATE_KEY, self.JWT_PUBLIC_KEY = (
+            generate_ephemeral_es256_keypair()
         )
-        self.JWT_PRIVATE_KEY = private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
-        ).decode('utf-8')
-
-        public_key = private_key.public_key()
-        self.JWT_PUBLIC_KEY = public_key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo
-        ).decode('utf-8')
 
 
 # Config dictionary

--- a/manager/backend/app/services/client_config_service.py
+++ b/manager/backend/app/services/client_config_service.py
@@ -12,9 +12,9 @@ Features:
 
 from __future__ import annotations
 
-import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from functools import wraps
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -27,30 +27,6 @@ logger = logging.getLogger(__name__)
 # the public-key-as-HMAC algorithm-confusion attack, consistent with the rest of
 # the platform (dns-server/dhcp-server/ntp-server verifiers).
 _DOMAIN_JWT_ALGORITHMS = ["ES256", "RS256"]
-
-
-def _generate_ephemeral_es256_keypair() -> tuple[str, str]:
-    """Generate an in-process ES256 keypair (PEM strings).
-
-    Used only when no manager keypair is supplied (standalone/dev/test). In a
-    real deployment the manager passes its configured JWT_PRIVATE_KEY /
-    JWT_PUBLIC_KEY so domain tokens are verifiable across replicas and restarts.
-    """
-    from cryptography.hazmat.primitives.asymmetric import ec
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.backends import default_backend
-
-    private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
-    private_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    ).decode("utf-8")
-    public_pem = private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
-    return private_pem, public_pem
 
 
 @dataclass(slots=True)
@@ -80,6 +56,49 @@ class OverrideRecord:
     created_by: Optional[str] = None
     created_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
+
+
+
+def _generate_ephemeral_es256_keypair() -> tuple[str, str]:
+    """Generate an in-process ES256 keypair (PEM strings).
+
+    Intentionally self-contained (duplicates app.utils.crypto): this module is
+    imported BARE (as ``client_config_service``) by the acceptance-test harness
+    with the services dir on sys.path, where ``app.*`` resolves to a different
+    package — so it must not import from ``app.*``.
+    """
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.backends import default_backend
+
+    private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return private_pem, public_pem
+
+
+def _with_db(method):
+    """Open a DB connection for the wrapped method and guarantee it closes.
+
+    The wrapped method receives the connection as its first argument after
+    ``self``. Centralizes the get/close lifecycle previously duplicated in
+    every method (``db = self._get_db()`` ... ``finally: db.close()``).
+    """
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        db = self._get_db()
+        try:
+            return method(self, db, *args, **kwargs)
+        finally:
+            db.close()
+    return wrapper
 
 
 class ClientConfigManager:
@@ -187,9 +206,9 @@ class ClientConfigManager:
             pass
         return None
 
-    def _initialize_default_roles(self) -> None:
+    @_with_db
+    def _initialize_default_roles(self, db: DB) -> None:
         """Create default configuration roles if they don't exist."""
-        db = self._get_db()
         try:
             # Define default roles
             default_roles = [
@@ -222,17 +241,16 @@ class ClientConfigManager:
             db.commit()
         except Exception as e:
             logger.warning(f"Failed to initialize default roles: {e}")
-        finally:
-            db.close()
 
+    @_with_db
     def create_deployment_domain(
         self,
+        db: DB,
         name: str,
         description: str = "",
         created_by: str = "",
     ) -> Dict[str, Any]:
         """Create a new deployment domain with JWT token."""
-        db = self._get_db()
         try:
             # Check for duplicate
             existing = db(db.deployment_domain.name == name).select().first()
@@ -263,12 +281,10 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to create deployment domain: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
-    def rollover_domain_jwt(self, domain_id: int, admin_user: str = "") -> Dict[str, Any]:
+    @_with_db
+    def rollover_domain_jwt(self, db: DB, domain_id: int, admin_user: str = "") -> Dict[str, Any]:
         """Generate new JWT token for deployment domain."""
-        db = self._get_db()
         try:
             domain = db(db.deployment_domain.id == domain_id).select().first()
             if not domain:
@@ -294,11 +310,11 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to rollover JWT: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
+    @_with_db
     def create_client_config(
         self,
+        db: DB,
         name: str,
         domain_id: int,
         config_data: Dict[str, Any],
@@ -306,7 +322,6 @@ class ClientConfigManager:
         created_by: str = "",
     ) -> Dict[str, Any]:
         """Create a new client configuration."""
-        db = self._get_db()
         try:
             # Validate config data
             if not self._validate_config_data(config_data):
@@ -339,18 +354,17 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to create client config: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
+    @_with_db
     def update_client_config(
         self,
+        db: DB,
         config_id: int,
         config_data: Dict[str, Any],
         description: str = "",
         changed_by: str = "",
     ) -> Dict[str, Any]:
         """Update an existing client configuration."""
-        db = self._get_db()
         try:
             config = db(db.client_config.id == config_id).select().first()
             if not config:
@@ -386,12 +400,10 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to update client config: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
-    def _verify_domain_jwt(self, jwt_token: str) -> Optional[Dict[str, Any]]:
+    @_with_db
+    def _verify_domain_jwt(self, db: DB, jwt_token: str) -> Optional[Dict[str, Any]]:
         """Verify domain JWT token and return domain info."""
-        db = self._get_db()
         try:
             # Verify signature with the public key. Expiry (`exp`) is enforced
             # natively by PyJWT; iss/aud are validated. HS256/none are rejected.
@@ -428,8 +440,6 @@ class ClientConfigManager:
             logger.warning("Invalid JWT token used for domain verification")
         except Exception as e:
             logger.error(f"JWT verification failed: {e}")
-        finally:
-            db.close()
 
         return None
 
@@ -471,8 +481,10 @@ class ClientConfigManager:
             logger.error(f"User token verification failed: {e}")
             return {"valid": False, "reason": "Token verification error"}
 
+    @_with_db
     def register_client(
         self,
+        db: DB,
         client_id: str,
         domain_jwt: str,
         hostname: str,
@@ -483,8 +495,6 @@ class ClientConfigManager:
         client_cert_subject: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Register a new client instance."""
-        db = self._get_db()
-
         try:
             # Verify user auth if provided
             if user_token:
@@ -555,19 +565,17 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to register client: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
+    @_with_db
     def pull_client_config(
         self,
+        db: DB,
         client_id: str,
         domain_jwt: str,
         user_token: Optional[str] = None,
         client_cert_subject: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Pull configuration for a client."""
-        db = self._get_db()
-
         try:
             # Verify user auth if provided
             if user_token:
@@ -633,18 +641,16 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to pull client config: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
+    @_with_db
     def assign_config_to_client(
         self,
+        db: DB,
         client_id: str,
         config_id: int,
         assigned_by: str = "",
     ) -> Dict[str, Any]:
         """Assign a specific configuration to a client."""
-        db = self._get_db()
-
         try:
             client = db(db.client_instance.client_id == client_id).select().first()
             if not client:
@@ -675,13 +681,10 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to assign config to client: {e}")
             return {"success": False, "error": str(e)}
-        finally:
-            db.close()
 
-    def get_domain_clients(self, domain_id: int) -> List[Dict[str, Any]]:
+    @_with_db
+    def get_domain_clients(self, db: DB, domain_id: int) -> List[Dict[str, Any]]:
         """Get all clients in a deployment domain."""
-        db = self._get_db()
-
         try:
             clients = db(db.client_instance.domain_id == domain_id).select()
 
@@ -717,13 +720,10 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to get domain clients: {e}")
             return []
-        finally:
-            db.close()
 
-    def get_client_stats(self) -> Dict[str, Any]:
+    @_with_db
+    def get_client_stats(self, db: DB) -> Dict[str, Any]:
         """Get client configuration statistics."""
-        db = self._get_db()
-
         try:
             # Domain stats
             all_domains = db(db.deployment_domain.id > 0).count()  # All deployment domains
@@ -763,13 +763,10 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to get client stats: {e}")
             return {}
-        finally:
-            db.close()
 
-    def cleanup_inactive_clients(self, inactive_days: int = 30) -> int:
+    @_with_db
+    def cleanup_inactive_clients(self, db: DB, inactive_days: int = 30) -> int:
         """Remove clients that haven't checked in for specified days."""
-        db = self._get_db()
-
         try:
             cutoff_time = datetime.now() - timedelta(days=inactive_days)
 
@@ -786,5 +783,3 @@ class ClientConfigManager:
         except Exception as e:
             logger.error(f"Failed to cleanup inactive clients: {e}")
             return 0
-        finally:
-            db.close()

--- a/manager/backend/app/utils/crypto.py
+++ b/manager/backend/app/utils/crypto.py
@@ -1,0 +1,32 @@
+"""Shared crypto helpers for the manager service."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def generate_ephemeral_es256_keypair() -> Tuple[str, str]:
+    """Generate an in-process ES256 (NIST P-256) keypair as PEM strings.
+
+    Returns:
+        (private_pem, public_pem)
+
+    Used only where no configured keypair is supplied (dev/test/standalone).
+    Production always supplies JWT_PRIVATE_KEY/JWT_PUBLIC_KEY — ProductionConfig
+    fails fast without them.
+    """
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.backends import default_backend
+
+    private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return private_pem, public_pem

--- a/manager/backend/tests/conftest.py
+++ b/manager/backend/tests/conftest.py
@@ -13,9 +13,6 @@ from unittest.mock import MagicMock
 import pytest
 import jwt
 from sqlalchemy import create_engine, text
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
 
 # Ensure app package is importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -95,24 +92,10 @@ def clean_tables(db):
 
 @pytest.fixture(scope="session")
 def jwt_keypair():
-    """Generate an ephemeral ES256 keypair for testing."""
-    # Generate EC private key (P-256)
-    private_key = ec.generate_private_key(
-        ec.SECP256R1(), default_backend()
-    )
-    private_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption()
-    ).decode('utf-8')
+    """Generate an ephemeral ES256 keypair for testing (shared helper)."""
+    from app.utils.crypto import generate_ephemeral_es256_keypair
 
-    # Extract public key
-    public_key = private_key.public_key()
-    public_pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
-    ).decode('utf-8')
-
+    private_pem, public_pem = generate_ephemeral_es256_keypair()
     return {
         'private': private_pem,
         'public': public_pem

--- a/manager/backend/tests/test_client_config_domain_jwt.py
+++ b/manager/backend/tests/test_client_config_domain_jwt.py
@@ -12,25 +12,9 @@ from datetime import datetime, timedelta, timezone
 
 import jwt
 import pytest
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
 
 from app.services.client_config_service import ClientConfigManager
-
-
-def _gen_es256_pem() -> tuple[str, str]:
-    key = ec.generate_private_key(ec.SECP256R1(), default_backend())
-    priv = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    ).decode()
-    pub = key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
-    return priv, pub
+from app.utils.crypto import generate_ephemeral_es256_keypair as _gen_es256_pem
 
 
 class _FakeField:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -27,8 +27,15 @@ class TestSquawkInstaller:
     
     def test_check_admin_windows(self):
         """Test admin check on Windows"""
+        import ctypes
+        from unittest.mock import MagicMock
+
+        # ctypes.windll only exists on Windows — attach a mock (create=True)
+        # so the Windows code path is exercisable on Linux/macOS CI.
+        windll = MagicMock()
+        windll.shell32.IsUserAnAdmin.return_value = 1
         with patch('platform.system', return_value='Windows'):
-            with patch('ctypes.windll.shell32.IsUserAnAdmin', return_value=1):
+            with patch.object(ctypes, 'windll', windll, create=True):
                 installer = SquawkInstaller()
                 assert installer.is_admin is True
     


### PR DESCRIPTION
Stacked on **#58**. Seventh branch in the chain. Reusable-code pass — no behavior changes; every affected suite re-verified.

## De-duplication
- **dns-server — one JWT verifier**: the identical ES256/RS256 verification contract (alg allowlist, iss/aud, required `exp`/`iat`/`tenant`, fail-closed) duplicated in `selective_router.py` and `resilience.py` now lives in `app/utils/jwt_verify.py` (`verify_squawk_jwt`). Authorization (zone visibility / team rules) stays with the callers. The 24 `@patch`-based auth-bypass regression tests run unchanged.
- **manager — DB lifecycle**: `client_config_service.py` had 12 copies of `db = self._get_db() … finally: db.close()`; replaced with a `_with_db` decorator that injects the connection and guarantees close (bodies untouched → low-risk diff).
- **manager — keypair generation**: new `app/utils/crypto.generate_ephemeral_es256_keypair()` consumed by `config.py` (Dev+Test blocks) and test helpers (conftest `jwt_keypair`, domain-JWT tests). `client_config_service` keeps a self-contained copy **by design** — it's imported bare by the acceptance harness where `app.*` resolves to a different package (rationale documented inline; discovered the hard way when the shared import broke all 25 acceptance tests).

## Also fixes
- 2 stale dns-server acceptance tests missed by the #54 asymmetric domain-JWT migration (still decoding with the removed HS256 `jwt_secret` attribute); the expired-token test now uses a genuinely expired ES256 token instead of exercising alg rejection.
- Pre-existing `tests/test_installer.py::test_check_admin_windows` failure: patching `ctypes.windll` can't resolve on Linux — mock attached with `create=True`.

## Verification
manager **142**, dns-server **58**, client-config acceptance **25**, root unit **67** — all passing. flake8/pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deduplicate JWT verification, DB connection lifecycle, and ES256 keypair generation across manager and dns-server while keeping behavior unchanged and fixing related test issues.

New Features:
- Introduce a shared Squawk JWT verification helper in dns-server for all authorization paths.
- Add a shared ES256 keypair generation utility in the manager service for dev/test and standalone usage.

Bug Fixes:
- Update dns-server client config API tests to verify ES256/RS256 domain tokens instead of legacy HS256 secrets.
- Ensure expired domain JWT tests use genuinely expired ES256 tokens signed with the manager keypair.
- Fix Windows admin-check installer test by safely mocking ctypes.windll so it runs on non-Windows platforms.

Enhancements:
- Centralize manager DB connection lifecycle via a decorator that injects and reliably closes connections, replacing repeated get/close blocks.
- Document and retain a self-contained ES256 keypair generator inside client_config_service to support the acceptance-test harness import model.

Tests:
- Refresh manager and dns-server JWT-related tests and fixtures to consume the new ES256 keypair helper and shared verification behavior.