### PR TITLE
feat(audit): durable tenant-scoped audit trail with query API

### DIFF
--- a/manager/backend/alembic/versions/008_audit_events.py
+++ b/manager/backend/alembic/versions/008_audit_events.py
@@ -1,0 +1,43 @@
+"""Add audit_event table — durable, SIEM-exportable audit trail.
+
+Revision ID: 008_audit_events
+Revises: 007_revoked_token
+"""
+from alembic import op
+from sqlalchemy import (
+    Column, DateTime, ForeignKey, Index, Integer, String, func
+)
+
+revision = "008_audit_events"
+down_revision = "007_revoked_token"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add durable audit event log."""
+    op.create_table(
+        'audit_event',
+        Column('id', Integer, primary_key=True, autoincrement=True),
+        Column('created_at', DateTime, nullable=False, server_default=func.now(), index=True),
+        Column('actor_id', Integer, ForeignKey('auth_user.id', ondelete='SET NULL')),
+        Column('tenant', String(100)),
+        Column('action', String(100), nullable=False, index=True),
+        Column('resource_type', String(50), index=True),
+        Column('resource_id', Integer, index=True),
+        Column('outcome', String(20), nullable=False, server_default='success'),
+        Column('status_code', Integer),
+        Column('request_id', String(36), index=True),
+        Column('source_ip', String(45)),
+    )
+    op.create_index('idx_audit_event_actor', 'audit_event', ['actor_id'])
+    op.create_index('idx_audit_event_action_created', 'audit_event', ['action', 'created_at'])
+    op.create_index('idx_audit_event_resource', 'audit_event', ['resource_type', 'resource_id'])
+
+
+def downgrade() -> None:
+    """Remove audit event log."""
+    op.drop_index('idx_audit_event_resource', table_name='audit_event')
+    op.drop_index('idx_audit_event_action_created', table_name='audit_event')
+    op.drop_index('idx_audit_event_actor', table_name='audit_event')
+    op.drop_table('audit_event')

--- a/manager/backend/alembic/versions/008_audit_events.py
+++ b/manager/backend/alembic/versions/008_audit_events.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
         Column('id', Integer, primary_key=True, autoincrement=True),
         Column('created_at', DateTime, nullable=False, server_default=func.now(), index=True),
         Column('actor_id', Integer, ForeignKey('auth_user.id', ondelete='SET NULL')),
-        Column('tenant', String(100)),
+        Column('tenant', String(100), index=True),
         Column('action', String(100), nullable=False, index=True),
         Column('resource_type', String(50), index=True),
         Column('resource_id', Integer, index=True),
@@ -32,12 +32,14 @@ def upgrade() -> None:
     )
     op.create_index('idx_audit_event_actor', 'audit_event', ['actor_id'])
     op.create_index('idx_audit_event_action_created', 'audit_event', ['action', 'created_at'])
+    op.create_index('idx_audit_event_tenant_created', 'audit_event', ['tenant', 'created_at'])
     op.create_index('idx_audit_event_resource', 'audit_event', ['resource_type', 'resource_id'])
 
 
 def downgrade() -> None:
     """Remove audit event log."""
     op.drop_index('idx_audit_event_resource', table_name='audit_event')
+    op.drop_index('idx_audit_event_tenant_created', table_name='audit_event')
     op.drop_index('idx_audit_event_action_created', table_name='audit_event')
     op.drop_index('idx_audit_event_actor', table_name='audit_event')
     op.drop_table('audit_event')

--- a/manager/backend/app/__init__.py
+++ b/manager/backend/app/__init__.py
@@ -112,6 +112,7 @@ def create_app(config_class: type = Config) -> Flask:
     from app.blueprints.analytics import analytics_bp
     from app.blueprints.dhcp import dhcp_bp
     from app.blueprints.time import time_bp
+    from app.blueprints.audit import audit_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(users_bp)
@@ -125,6 +126,7 @@ def create_app(config_class: type = Config) -> Flask:
     app.register_blueprint(analytics_bp)
     app.register_blueprint(dhcp_bp)
     app.register_blueprint(time_bp)
+    app.register_blueprint(audit_bp)
 
     # Health check endpoint
     @app.route('/health')

--- a/manager/backend/app/blueprints/audit.py
+++ b/manager/backend/app/blueprints/audit.py
@@ -1,0 +1,147 @@
+"""Audit event API — query durable audit trail.
+
+Gated on scope audit:read (default granted to SystemAdmin).
+Supports filtering by action, actor_id, resource_type, outcome, date range.
+"""
+
+from datetime import datetime
+from flask import Blueprint, request, jsonify, current_app
+from app.middleware.auth import token_required
+from app.middleware.rbac import requires_scope
+
+audit_bp = Blueprint('audit', __name__)
+
+
+@audit_bp.route('/api/v1/audit-events', methods=['GET'])
+@token_required
+@requires_scope('audit:read')
+def list_audit_events():
+    """List audit events with optional filtering.
+
+    Query params:
+        - action: Filter by action name (e.g., 'user_created')
+        - actor_id: Filter by actor user ID
+        - resource_type: Filter by resource type (e.g., 'token', 'dns_server')
+        - resource_id: Filter by specific resource ID
+        - outcome: Filter by outcome ('success' or 'failure')
+        - since: ISO 8601 datetime (inclusive); events after this time
+        - until: ISO 8601 datetime (inclusive); events before this time
+        - limit: Max results (default 50, max 500)
+        - offset: Pagination offset (default 0)
+
+    Response:
+        {
+            "events": [
+                {
+                    "id": 1,
+                    "created_at": "2026-07-25T12:00:00",
+                    "actor_id": 123,
+                    "action": "user_created",
+                    "resource_type": "user",
+                    "resource_id": 456,
+                    "outcome": "success",
+                    "status_code": 201,
+                    "request_id": "abc-123",
+                    "source_ip": "192.168.1.1"
+                }
+            ],
+            "total": 150,
+            "limit": 50,
+            "offset": 0
+        }
+    """
+    db = current_app.db
+
+    # Build query filters
+    query = None
+
+    # Filter by action
+    action = request.args.get('action')
+    if action:
+        query = db.audit_event.action == action if query is None else query & (db.audit_event.action == action)
+
+    # Filter by actor_id
+    actor_id = request.args.get('actor_id', type=int)
+    if actor_id is not None:
+        cond = db.audit_event.actor_id == actor_id
+        query = cond if query is None else query & cond
+
+    # Filter by resource_type
+    resource_type = request.args.get('resource_type')
+    if resource_type:
+        cond = db.audit_event.resource_type == resource_type
+        query = cond if query is None else query & cond
+
+    # Filter by resource_id
+    resource_id = request.args.get('resource_id', type=int)
+    if resource_id is not None:
+        cond = db.audit_event.resource_id == resource_id
+        query = cond if query is None else query & cond
+
+    # Filter by outcome
+    outcome = request.args.get('outcome')
+    if outcome:
+        if outcome not in ('success', 'failure'):
+            return jsonify({'error': 'Invalid outcome; must be "success" or "failure"'}), 400
+        cond = db.audit_event.outcome == outcome
+        query = cond if query is None else query & cond
+
+    # Filter by date range
+    since = request.args.get('since')
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since)
+            cond = db.audit_event.created_at >= since_dt
+            query = cond if query is None else query & cond
+        except ValueError:
+            return jsonify({'error': 'Invalid "since" datetime; use ISO 8601 format'}), 400
+
+    until = request.args.get('until')
+    if until:
+        try:
+            until_dt = datetime.fromisoformat(until)
+            cond = db.audit_event.created_at <= until_dt
+            query = cond if query is None else query & cond
+        except ValueError:
+            return jsonify({'error': 'Invalid "until" datetime; use ISO 8601 format'}), 400
+
+    # Pagination
+    limit = request.args.get('limit', default=50, type=int)
+    offset = request.args.get('offset', default=0, type=int)
+
+    if limit < 1 or limit > 500:
+        return jsonify({'error': 'limit must be between 1 and 500'}), 400
+    if offset < 0:
+        return jsonify({'error': 'offset must be >= 0'}), 400
+
+    # Count total matching and fetch records
+    if query is None:
+        # No filters — use a tautology to select all rows
+        query = db.audit_event.id != None  # Every row's id is not null
+
+    total = db(query).count()
+    events = db(query).select(
+        orderby=~db.audit_event.created_at,
+        limitby=(offset, offset + limit)
+    )
+
+    return jsonify({
+        'events': [
+            {
+                'id': e.id,
+                'created_at': e.created_at.isoformat(),
+                'actor_id': e.actor_id,
+                'action': e.action,
+                'resource_type': e.resource_type,
+                'resource_id': e.resource_id,
+                'outcome': e.outcome,
+                'status_code': e.status_code,
+                'request_id': e.request_id,
+                'source_ip': e.source_ip,
+            }
+            for e in events
+        ],
+        'total': total,
+        'limit': limit,
+        'offset': offset,
+    }), 200

--- a/manager/backend/app/blueprints/audit.py
+++ b/manager/backend/app/blueprints/audit.py
@@ -21,6 +21,7 @@ def list_audit_events():
     Query params:
         - action: Filter by action name (e.g., 'user_created')
         - actor_id: Filter by actor user ID
+        - tenant: Filter by tenant name
         - resource_type: Filter by resource type (e.g., 'token', 'dns_server')
         - resource_id: Filter by specific resource ID
         - outcome: Filter by outcome ('success' or 'failure')
@@ -36,6 +37,7 @@ def list_audit_events():
                     "id": 1,
                     "created_at": "2026-07-25T12:00:00",
                     "actor_id": 123,
+                    "tenant": "default",
                     "action": "user_created",
                     "resource_type": "user",
                     "resource_id": 456,
@@ -64,6 +66,12 @@ def list_audit_events():
     actor_id = request.args.get('actor_id', type=int)
     if actor_id is not None:
         cond = db.audit_event.actor_id == actor_id
+        query = cond if query is None else query & cond
+
+    # Filter by tenant
+    tenant = request.args.get('tenant')
+    if tenant:
+        cond = db.audit_event.tenant == tenant
         query = cond if query is None else query & cond
 
     # Filter by resource_type
@@ -131,6 +139,7 @@ def list_audit_events():
                 'id': e.id,
                 'created_at': e.created_at.isoformat(),
                 'actor_id': e.actor_id,
+                'tenant': e.tenant,
                 'action': e.action,
                 'resource_type': e.resource_type,
                 'resource_id': e.resource_id,

--- a/manager/backend/app/middleware/auth.py
+++ b/manager/backend/app/middleware/auth.py
@@ -47,7 +47,8 @@ def token_required(f):
             'scope': payload.get('scope', ''),
             'global_role': payload.get('global_role'),
             'team_roles': payload.get('team_roles', {}),
-            'token_type': payload.get('type')
+            'token_type': payload.get('type'),
+            'tenant': payload.get('tenant'),  # For audit trail tenant scoping
         }
 
         return f(*args, **kwargs)

--- a/manager/backend/app/schema.py
+++ b/manager/backend/app/schema.py
@@ -590,7 +590,7 @@ audit_event = Table(
     Column("id", Integer, primary_key=True, autoincrement=True),
     Column("created_at", DateTime, nullable=False, server_default=func.now(), index=True),
     Column("actor_id", Integer, ForeignKey("auth_user.id", ondelete="SET NULL")),
-    Column("tenant", String(100)),  # Multi-tenancy support; NULL = default tenant
+    Column("tenant", String(100), index=True),  # Multi-tenancy support; nullable for cross-tenant audit
     Column("action", String(100), nullable=False, index=True),
     Column("resource_type", String(50), index=True),  # E.g., 'dns_server', 'token', 'user'
     Column("resource_id", Integer, index=True),
@@ -601,4 +601,5 @@ audit_event = Table(
 )
 Index("idx_audit_event_actor", audit_event.c.actor_id)
 Index("idx_audit_event_action_created", audit_event.c.action, audit_event.c.created_at)
+Index("idx_audit_event_tenant_created", audit_event.c.tenant, audit_event.c.created_at)
 Index("idx_audit_event_resource", audit_event.c.resource_type, audit_event.c.resource_id)

--- a/manager/backend/app/schema.py
+++ b/manager/backend/app/schema.py
@@ -581,3 +581,24 @@ revoked_token = Table(
     Column("expires_at", DateTime, nullable=False),
 )
 Index("idx_revoked_token_expires", revoked_token.c.expires_at)
+
+# ── Audit events (durable, SIEM-exportable) ──────────────────────────────────
+
+audit_event = Table(
+    "audit_event",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("created_at", DateTime, nullable=False, server_default=func.now(), index=True),
+    Column("actor_id", Integer, ForeignKey("auth_user.id", ondelete="SET NULL")),
+    Column("tenant", String(100)),  # Multi-tenancy support; NULL = default tenant
+    Column("action", String(100), nullable=False, index=True),
+    Column("resource_type", String(50), index=True),  # E.g., 'dns_server', 'token', 'user'
+    Column("resource_id", Integer, index=True),
+    Column("outcome", String(20), nullable=False, server_default="success"),  # 'success' | 'failure'
+    Column("status_code", Integer),  # HTTP status or error code
+    Column("request_id", String(36), index=True),  # For request tracing
+    Column("source_ip", String(45)),  # IPv4 or IPv6
+)
+Index("idx_audit_event_actor", audit_event.c.actor_id)
+Index("idx_audit_event_action_created", audit_event.c.action, audit_event.c.created_at)
+Index("idx_audit_event_resource", audit_event.c.resource_type, audit_event.c.resource_id)

--- a/manager/backend/app/services/scopes.py
+++ b/manager/backend/app/services/scopes.py
@@ -27,7 +27,7 @@ SUPERADMIN_SCOPE = "admin:super"
 _READ_SCOPES: List[str] = [
     "users:read", "servers:read", "teams:read", "time:read",
     "dhcp:read", "ioc:read", "zones:read", "tokens:read",
-    "analytics:read", "whois:read", "audit:read",
+    "analytics:read", "whois:read",
 ]
 
 # Global role → concrete scope bundle.
@@ -40,6 +40,7 @@ ROLE_SCOPES: Dict[str, List[str]] = {
         "time:write", "time:admin",
         "dhcp:write", "dhcp:admin",
         "ioc:admin",
+        "audit:read",  # SystemAdmin only (no least-privilege leak to other roles)
     ] + _READ_SCOPES,
     "OrgAdmin": [
         "servers:write", "teams:write", "time:write", "dhcp:write",

--- a/manager/backend/app/services/scopes.py
+++ b/manager/backend/app/services/scopes.py
@@ -27,7 +27,7 @@ SUPERADMIN_SCOPE = "admin:super"
 _READ_SCOPES: List[str] = [
     "users:read", "servers:read", "teams:read", "time:read",
     "dhcp:read", "ioc:read", "zones:read", "tokens:read",
-    "analytics:read", "whois:read",
+    "analytics:read", "whois:read", "audit:read",
 ]
 
 # Global role → concrete scope bundle.

--- a/manager/backend/app/utils/decorators.py
+++ b/manager/backend/app/utils/decorators.py
@@ -222,6 +222,7 @@ def audit_log(action: str, resource_type: str | None = None):
 
             user = get_current_user()
             actor_id = user.get('user_id') if user else None
+            tenant = user.get('tenant') if user else None
             source_ip = request.remote_addr
 
             # Attempt to infer resource_id from route kwargs
@@ -265,6 +266,7 @@ def audit_log(action: str, resource_type: str | None = None):
                     db.audit_event.insert(
                         action=action,
                         actor_id=actor_id,
+                        tenant=tenant,
                         resource_type=inferred_resource_type,
                         resource_id=resource_id,
                         outcome=outcome,
@@ -300,6 +302,7 @@ def audit_log(action: str, resource_type: str | None = None):
                 db.audit_event.insert(
                     action=action,
                     actor_id=actor_id,
+                    tenant=tenant,
                     resource_type=inferred_resource_type,
                     resource_id=resource_id,
                     outcome=outcome,

--- a/manager/backend/app/utils/decorators.py
+++ b/manager/backend/app/utils/decorators.py
@@ -192,30 +192,140 @@ def handle_db_errors(f):
     return decorated_function
 
 
-def audit_log(action: str):
+def audit_log(action: str, resource_type: str | None = None):
     """
-    Decorator to log actions for audit trail.
+    Decorator to log actions for durable audit trail.
+
+    Writes audit events to the database and emits structured JSON logs.
+    Never emits PII (no username, email, etc.) — only user_id.
+    Audit write failures are logged but never fail the request (fail-open).
 
     Args:
-        action: Description of the action
+        action: Action name (e.g., 'user_created', 'token_deleted')
+        resource_type: Optional resource type (auto-extracted from route kwargs if not provided)
 
     Example:
-        @audit_log('user_created')
-        def create_user():
+        @audit_log('user_created', resource_type='user')
+        def create_user(user_id):
+            ...
+
+        @audit_log('token_deleted')  # resource_type inferred from context
+        def delete_token(token_id):
             ...
     """
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
+            import json
+            from datetime import datetime
             from app.middleware.auth import get_current_user
 
             user = get_current_user()
-            user_id = user.get('user_id') if user else None
-            username = user.get('username') if user else 'anonymous'
+            actor_id = user.get('user_id') if user else None
+            source_ip = request.remote_addr
 
-            logger.info(f"AUDIT: {action} by {username} (user_id={user_id})")
+            # Attempt to infer resource_id from route kwargs
+            resource_id = None
+            inferred_resource_type = resource_type
+            for key_pattern in ['_id', 'id']:
+                for key in kwargs:
+                    if key.endswith(key_pattern):
+                        resource_id = kwargs[key]
+                        if not inferred_resource_type:
+                            # Extract type from key: 'token_id' -> 'token', 'server_id' -> 'server'
+                            inferred_resource_type = key.rsplit('_id' if key.endswith('_id') else 'id', 1)[0]
+                        break
 
-            result = f(*args, **kwargs)
+            try:
+                # Execute the wrapped function
+                result = f(*args, **kwargs)
+
+                # Extract outcome from result
+                outcome = 'success'
+                status_code = 200
+                if isinstance(result, tuple) and len(result) >= 2:
+                    # Flask route returned (response, status_code)
+                    _, status_code = result[0:2]
+                    outcome = 'success' if status_code < 400 else 'failure'
+                elif isinstance(result, dict):
+                    status_code = 200
+
+                # Extract request_id if present in headers or response
+                request_id = request.headers.get('X-Request-ID')
+
+            except Exception as e:
+                # Audit the failure, log the error, re-raise
+                outcome = 'failure'
+                status_code = 500
+                request_id = request.headers.get('X-Request-ID')
+
+                # Attempt to write failure audit record
+                try:
+                    db = current_app.db
+                    db.audit_event.insert(
+                        action=action,
+                        actor_id=actor_id,
+                        resource_type=inferred_resource_type,
+                        resource_id=resource_id,
+                        outcome=outcome,
+                        status_code=status_code,
+                        request_id=request_id,
+                        source_ip=source_ip,
+                    )
+                    db.commit()
+                except Exception as audit_err:
+                    # Log audit write failure but don't fail the request
+                    logger.error(f"Audit write failed for {action}: {audit_err}")
+
+                # Emit structured JSON log (no PII)
+                log_entry = {
+                    'event_type': 'audit',
+                    'action': action,
+                    'actor_id': actor_id,
+                    'resource_type': inferred_resource_type,
+                    'resource_id': resource_id,
+                    'outcome': outcome,
+                    'status_code': status_code,
+                    'request_id': request_id,
+                    'source_ip': source_ip,
+                    'timestamp': datetime.utcnow().isoformat(),
+                }
+                logger.error(f"AUDIT_EVENT {json.dumps(log_entry)}")
+
+                raise
+
+            # Write audit event to database
+            try:
+                db = current_app.db
+                db.audit_event.insert(
+                    action=action,
+                    actor_id=actor_id,
+                    resource_type=inferred_resource_type,
+                    resource_id=resource_id,
+                    outcome=outcome,
+                    status_code=status_code,
+                    request_id=request_id,
+                    source_ip=source_ip,
+                )
+                db.commit()
+            except Exception as e:
+                # Log audit write failure but don't fail the request
+                logger.error(f"Audit write failed for {action}: {e}")
+
+            # Emit structured JSON log (no PII — only user_id, no username/email)
+            log_entry = {
+                'event_type': 'audit',
+                'action': action,
+                'actor_id': actor_id,
+                'resource_type': inferred_resource_type,
+                'resource_id': resource_id,
+                'outcome': outcome,
+                'status_code': status_code,
+                'request_id': request_id,
+                'source_ip': source_ip,
+                'timestamp': datetime.utcnow().isoformat(),
+            }
+            logger.info(f"AUDIT_EVENT {json.dumps(log_entry)}")
 
             return result
         return decorated_function

--- a/manager/backend/tests/test_audit.py
+++ b/manager/backend/tests/test_audit.py
@@ -1,0 +1,370 @@
+"""Tests for audit logging and audit events API.
+
+Tests audit_events table schema, endpoint scope enforcement, and filter coverage.
+"""
+
+from datetime import datetime, timedelta
+import pytest
+
+from app.services.scopes import expand_scopes
+
+
+@pytest.fixture
+def admin_token(app):
+    """JWT token for SystemAdmin role."""
+    from app.services.auth_service import AuthService
+
+    with app.app_context():
+        db = app.db
+        user = db.auth_user.insert(
+            username='admin',
+            email='admin@example.com',
+            password_hash='hashed',
+            global_role='SystemAdmin'
+        )
+        db.commit()
+        return AuthService.create_access_token(
+            user_id=user,
+            username='admin',
+            global_role='SystemAdmin',
+            team_roles={}
+        )
+
+
+@pytest.fixture
+def viewer_token(app):
+    """JWT token for Viewer role."""
+    from app.services.auth_service import AuthService
+
+    with app.app_context():
+        db = app.db
+        user = db.auth_user.insert(
+            username='viewer',
+            email='viewer@example.com',
+            password_hash='hashed',
+            global_role='Viewer'
+        )
+        db.commit()
+        return AuthService.create_access_token(
+            user_id=user,
+            username='viewer',
+            global_role='Viewer',
+            team_roles={}
+        )
+
+
+class TestAuditEventsAPI:
+    """Test GET /api/v1/audit-events endpoint."""
+
+    def test_endpoint_requires_auth(self, app):
+        """GET /api/v1/audit-events requires authentication."""
+        with app.test_client() as client:
+            response = client.get('/api/v1/audit-events')
+            assert response.status_code == 401
+
+    def test_endpoint_returns_empty_on_no_events(self, app, admin_token):
+        """GET /api/v1/audit-events returns empty list when no events."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['events'] == []
+            assert data['total'] == 0
+
+    def test_endpoint_filter_by_action(self, app, admin_token):
+        """GET /api/v1/audit-events?action=X filters by action."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(action='user_created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(action='user_deleted', outcome='success', status_code=200, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?action=user_created',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['action'] == 'user_created'
+
+    def test_endpoint_filter_by_actor_id(self, app, admin_token):
+        """GET /api/v1/audit-events?actor_id=X filters by actor."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(actor_id=1, action='user_created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(actor_id=2, action='user_created', outcome='success', status_code=201, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?actor_id=1',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['actor_id'] == 1
+
+    def test_endpoint_filter_by_resource_type(self, app, admin_token):
+        """GET /api/v1/audit-events?resource_type=X filters by resource type."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(resource_type='user', action='created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(resource_type='token', action='created', outcome='success', status_code=201, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?resource_type=user',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['resource_type'] == 'user'
+
+    def test_endpoint_filter_by_resource_id(self, app, admin_token):
+        """GET /api/v1/audit-events?resource_id=X filters by resource ID."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(resource_id=1, action='deleted', outcome='success', status_code=200, created_at=now)
+            db.audit_event.insert(resource_id=2, action='deleted', outcome='success', status_code=200, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?resource_id=1',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['resource_id'] == 1
+
+    def test_endpoint_filter_by_outcome(self, app, admin_token):
+        """GET /api/v1/audit-events?outcome=X filters by outcome."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(action='test', outcome='success', status_code=200, created_at=now)
+            db.audit_event.insert(action='test', outcome='failure', status_code=400, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?outcome=success',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['outcome'] == 'success'
+
+    def test_endpoint_filter_by_outcome_invalid(self, app, admin_token):
+        """GET /api/v1/audit-events?outcome=invalid returns 400."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?outcome=invalid',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 400
+            data = response.get_json()
+            assert 'error' in data
+
+    def test_endpoint_filter_by_since(self, app, admin_token):
+        """GET /api/v1/audit-events?since=ISO_DATE filters by created_at >= since."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            earlier = now - timedelta(hours=1)
+            db.audit_event.insert(action='old', outcome='success', status_code=200, created_at=earlier)
+            db.audit_event.insert(action='new', outcome='success', status_code=200, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            since_str = (now - timedelta(minutes=30)).isoformat()
+            response = client.get(
+                f'/api/v1/audit-events?since={since_str}',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['action'] == 'new'
+
+    def test_endpoint_filter_by_since_invalid(self, app, admin_token):
+        """GET /api/v1/audit-events?since=invalid returns 400."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?since=not-a-date',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 400
+
+    def test_endpoint_filter_by_until(self, app, admin_token):
+        """GET /api/v1/audit-events?until=ISO_DATE filters by created_at <= until."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            later = now + timedelta(hours=1)
+            db.audit_event.insert(action='now', outcome='success', status_code=200, created_at=now)
+            db.audit_event.insert(action='future', outcome='success', status_code=200, created_at=later)
+            db.commit()
+
+        with app.test_client() as client:
+            until_str = (now + timedelta(minutes=30)).isoformat()
+            response = client.get(
+                f'/api/v1/audit-events?until={until_str}',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['action'] == 'now'
+
+    def test_endpoint_filter_by_until_invalid(self, app, admin_token):
+        """GET /api/v1/audit-events?until=invalid returns 400."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?until=not-a-date',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 400
+
+    def test_endpoint_pagination_limit_default(self, app, admin_token):
+        """GET /api/v1/audit-events uses default limit of 50."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            for i in range(75):
+                db.audit_event.insert(action=f'test_{i}', outcome='success', status_code=200, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert len(data['events']) == 50
+            assert data['limit'] == 50
+            assert data['total'] == 75
+
+    def test_endpoint_pagination_custom_limit(self, app, admin_token):
+        """GET /api/v1/audit-events?limit=N respects custom limit."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            for i in range(100):
+                db.audit_event.insert(action=f'test_{i}', outcome='success', status_code=200, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?limit=25',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert len(data['events']) == 25
+            assert data['limit'] == 25
+
+    def test_endpoint_pagination_limit_too_large(self, app, admin_token):
+        """GET /api/v1/audit-events?limit=501 returns 400."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?limit=501',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 400
+
+    def test_endpoint_pagination_limit_too_small(self, app, admin_token):
+        """GET /api/v1/audit-events?limit=0 returns 400."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?limit=0',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 400
+
+    def test_endpoint_pagination_offset_negative(self, app, admin_token):
+        """GET /api/v1/audit-events?offset=-1 returns 400."""
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?offset=-1',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 400
+
+    def test_endpoint_combined_filters(self, app, admin_token):
+        """GET /api/v1/audit-events with multiple filters."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(actor_id=1, resource_type='user', action='created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(actor_id=1, resource_type='token', action='created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(actor_id=2, resource_type='user', action='created', outcome='success', status_code=201, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?actor_id=1&resource_type=user',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['actor_id'] == 1
+            assert data['events'][0]['resource_type'] == 'user'
+
+    def test_endpoint_response_format(self, app, admin_token):
+        """GET /api/v1/audit-events response includes all required fields."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(
+                actor_id=1,
+                action='test_action',
+                resource_type='test_resource',
+                resource_id=42,
+                outcome='success',
+                status_code=200,
+                request_id='req-123',
+                source_ip='192.168.1.1',
+                created_at=now
+            )
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert 'events' in data
+            assert 'total' in data
+            assert 'limit' in data
+            assert 'offset' in data
+
+            event = data['events'][0]
+            assert 'id' in event
+            assert 'created_at' in event
+            assert 'actor_id' in event
+            assert 'action' in event
+            assert 'resource_type' in event
+            assert 'resource_id' in event
+            assert 'outcome' in event
+            assert 'status_code' in event
+            assert 'request_id' in event
+            assert 'source_ip' in event

--- a/manager/backend/tests/test_audit.py
+++ b/manager/backend/tests/test_audit.py
@@ -53,6 +53,28 @@ def viewer_token(app):
         )
 
 
+@pytest.fixture
+def orgadmin_token(app):
+    """JWT token for OrgAdmin role."""
+    from app.services.auth_service import AuthService
+
+    with app.app_context():
+        db = app.db
+        user = db.auth_user.insert(
+            username='orgadmin',
+            email='orgadmin@example.com',
+            password_hash='hashed',
+            global_role='OrgAdmin'
+        )
+        db.commit()
+        return AuthService.create_access_token(
+            user_id=user,
+            username='orgadmin',
+            global_role='OrgAdmin',
+            team_roles={}
+        )
+
+
 class TestAuditEventsAPI:
     """Test GET /api/v1/audit-events endpoint."""
 
@@ -61,6 +83,30 @@ class TestAuditEventsAPI:
         with app.test_client() as client:
             response = client.get('/api/v1/audit-events')
             assert response.status_code == 401
+
+    def test_endpoint_requires_audit_read_scope_systemadmin_only(self, app, viewer_token, orgadmin_token, admin_token):
+        """GET /api/v1/audit-events requires audit:read (SystemAdmin only)."""
+        with app.test_client() as client:
+            # Viewer: 403
+            response = client.get(
+                '/api/v1/audit-events',
+                headers={'Authorization': f'Bearer {viewer_token}'}
+            )
+            assert response.status_code == 403
+
+            # OrgAdmin: 403
+            response = client.get(
+                '/api/v1/audit-events',
+                headers={'Authorization': f'Bearer {orgadmin_token}'}
+            )
+            assert response.status_code == 403
+
+            # SystemAdmin: 200
+            response = client.get(
+                '/api/v1/audit-events',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
 
     def test_endpoint_returns_empty_on_no_events(self, app, admin_token):
         """GET /api/v1/audit-events returns empty list when no events."""
@@ -361,6 +407,7 @@ class TestAuditEventsAPI:
             assert 'id' in event
             assert 'created_at' in event
             assert 'actor_id' in event
+            assert 'tenant' in event
             assert 'action' in event
             assert 'resource_type' in event
             assert 'resource_id' in event
@@ -368,3 +415,43 @@ class TestAuditEventsAPI:
             assert 'status_code' in event
             assert 'request_id' in event
             assert 'source_ip' in event
+
+    def test_endpoint_filter_by_tenant(self, app, admin_token):
+        """GET /api/v1/audit-events?tenant=X filters by tenant."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(tenant='default', action='created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(tenant='acme', action='created', outcome='success', status_code=201, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?tenant=default',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['tenant'] == 'default'
+
+    def test_endpoint_filter_by_tenant_combined(self, app, admin_token):
+        """GET /api/v1/audit-events?tenant=X&action=Y filters by both tenant and action."""
+        db = app.db
+        with app.app_context():
+            now = datetime.utcnow()
+            db.audit_event.insert(tenant='default', action='created', outcome='success', status_code=201, created_at=now)
+            db.audit_event.insert(tenant='default', action='deleted', outcome='success', status_code=200, created_at=now)
+            db.audit_event.insert(tenant='acme', action='created', outcome='success', status_code=201, created_at=now)
+            db.commit()
+
+        with app.test_client() as client:
+            response = client.get(
+                '/api/v1/audit-events?tenant=default&action=created',
+                headers={'Authorization': f'Bearer {admin_token}'}
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data['total'] == 1
+            assert data['events'][0]['tenant'] == 'default'
+            assert data['events'][0]['action'] == 'created'

--- a/manager/backend/tests/test_schema.py
+++ b/manager/backend/tests/test_schema.py
@@ -31,6 +31,8 @@ def test_schema_creates_all_tables():
         "mtls_certificate", "mtls_revocation",
         # refresh-token rotation/revocation
         "revoked_token",
+        # durable audit trail
+        "audit_event",
     }
     assert expected == tables
     engine.dispose()


### PR DESCRIPTION
Replaces the log-line-only `@audit_log` with a durable audit trail: `audit_event` table (actor_id/tenant/action/resource/outcome/status/request_id/source_ip — no PII), fail-open DB write + single-line JSON log (SIEM-ready) on success and failure paths, and `GET /api/v1/audit-events` with filters (action, actor_id, tenant, resource_type, outcome, since/until) + pagination. `audit:read` granted to SystemAdmin only (least privilege — Viewer/OrgAdmin get 403, tested).

**Tests:** 164 green (26 audit-specific). All 8 existing @audit_log call sites unchanged.
**Merge note:** contains alembic migration `008` — collides with 008 in the MFA and NHI branches; renumber whichever merges later.
---
**Stack note:** bases on `chore/dedup-reusable-code` (top of the #53–#59 chain); auto-retargets toward `v2.1.x` as the stack merges bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a durable, queryable audit trail with a new audit_event table and API, replacing the previous log-only audit decorator.

New Features:
- Add tenant-scoped audit_event table with indices for actor, action, tenant, and resource for durable audit logging.
- Expose GET /api/v1/audit-events API with filtering (tenant, actor, action, resource, outcome, date range) and pagination, gated by audit:read scope for SystemAdmin.
- Extend the audit_log decorator to persist audit events to the database and emit structured JSON logs without PII.

Enhancements:
- Propagate tenant information into the auth middleware context to support tenant-scoped auditing.

Build:
- Add Alembic migration to create the audit_event table and related indices.

Tests:
- Add comprehensive tests for the audit events API, including auth/scope enforcement, filtering, pagination, and response format.
- Extend schema tests to assert creation of the new audit_event table.