### PR TITLE
docs(enterprise): DR, HA, supply-chain verification, CoreDNS guides

### DIFF
--- a/docs/enterprise/COREDNS-INTEGRATION.md
+++ b/docs/enterprise/COREDNS-INTEGRATION.md
@@ -1,0 +1,297 @@
+# CoreDNS Integration
+
+## Squawk as Upstream DoH Resolver
+
+Squawk dns-server exposes a DNS-over-HTTPS endpoint that CoreDNS can forward queries to. This allows in-cluster DNS (CoreDNS) to offload resolution to Squawk with authentication and access control.
+
+## Squawk Service & Ports
+
+From the Helm chart (k8s/helm/squawk/templates/dns-server-service.yml):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-server
+  namespace: squawk
+spec:
+  type: ClusterIP
+  ports:
+  - name: doh
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+```
+
+**Endpoint:** `http://dns-server.squawk.svc.cluster.local:8080/dns-query` (DoH/HTTP endpoint)
+
+**Note:** Squawk currently exposes DoH (HTTP-based DNS) only. Standard UDP port 53 DNS is NOT available in the chart deployment. CoreDNS can forward via the DoH endpoint or use squawk-dns-client (k8s-dns sidecar) for UDP forwarding.
+
+## CoreDNS Configuration
+
+### Option A: Forward via squawk-dns-client (K8s DNS Sidecar)
+
+Squawk includes a k8s-dns component that integrates with CoreDNS:
+
+```yaml
+# CoreDNS ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+      errors
+      health
+      ready
+      kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+      }
+      # Forward to Squawk k8s-dns (listens on 5300)
+      forward . dns-client.squawk.svc.cluster.local:5300 {
+        policy round_robin
+        max_fails 2
+        health_uri /health
+        health_port 5300
+      }
+      prometheus :9153
+      loop
+      reload
+    }
+```
+
+**How it works:**
+1. CoreDNS forwards unknown domains to `dns-client.squawk.svc.cluster.local:5300`
+2. squawk-dns-client (K8s DNS sidecar) queries squawk dns-server via HTTP
+3. dns-server authenticates via JWT (Bearer token in HTTP Authorization header)
+4. Response cached in Valkey and returned to CoreDNS
+
+### Option B: Direct DoH Forward to squawk dns-server
+
+If CoreDNS has DoH support (newer versions), forward directly:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+      errors
+      health
+      ready
+      kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+      }
+      # Forward via DoH (requires CoreDNS with DoH plugin)
+      forward . https://dns-server.squawk.svc.cluster.local:8080/dns-query {
+        policy round_robin
+        max_fails 2
+        # Bearer token for authentication
+        header Authorization "Bearer <JWT-token>"
+      }
+      prometheus :9153
+      loop
+      reload
+    }
+```
+
+**Note:** As of CoreDNS v1.10, DoH forwarding may require additional plugins or a proxy sidecar.
+
+## JWT Authentication Setup
+
+Both options require a valid JWT token from the Squawk manager:
+
+1. **Issue token via manager:**
+
+```bash
+# Request token from Squawk manager API (port 5000)
+curl -X POST http://manager.squawk.svc.cluster.local:5000/api/v1/tokens \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-token>" \
+  -d '{"name": "coredns-upstream", "scopes": ["dns:query"]}'
+
+# Response:
+# {"token": "eyJhbGc...", "created": "2025-01-15T..."}
+```
+
+2. **Store token in K8s Secret:**
+
+```bash
+kubectl create secret generic squawk-dns-token \
+  -n kube-system \
+  --from-literal=token=eyJhbGc...
+```
+
+3. **Reference in CoreDNS ConfigMap:**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+      forward . dns-client.squawk.svc.cluster.local:5300 {
+        policy round_robin
+      }
+    }
+```
+
+Or for direct DoH:
+
+```yaml
+# Update deployment to mount secret and inject Bearer token
+# (Requires wrapper script or sidecar to add header)
+```
+
+## Deployment Example
+
+### Step 1: Deploy Squawk
+
+```bash
+helm install squawk ./k8s/helm/squawk \
+  --namespace squawk --create-namespace \
+  --values k8s/helm/squawk/values.yaml \
+  --values k8s/helm/squawk/production.yml
+```
+
+### Step 2: Issue CoreDNS JWT Token
+
+```bash
+ADMIN_TOKEN=$(kubectl get secret -n squawk manager-admin-token -o jsonpath='{.data.token}' | base64 -d)
+
+COREDNS_TOKEN=$(curl -s -X POST http://manager.squawk.svc.cluster.local:5000/api/v1/tokens \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -d '{"name": "coredns", "scopes": ["dns:query"], "tenant_id": "default"}' | jq -r .token)
+
+echo $COREDNS_TOKEN
+```
+
+### Step 3: Store in CoreDNS Namespace
+
+```bash
+kubectl create secret generic squawk-dns-token \
+  -n kube-system \
+  --from-literal=token=${COREDNS_TOKEN}
+```
+
+### Step 4: Update CoreDNS ConfigMap
+
+```bash
+kubectl patch configmap coredns -n kube-system --type merge -p '{
+  "data": {
+    "Corefile": ".:53 {\n  errors\n  health\n  ready\n  kubernetes cluster.local in-addr.arpa ip6.arpa {\n    pods insecure\n    fallthrough in-addr.arpa ip6.arpa\n  }\n  forward . dns-client.squawk.svc.cluster.local:5300 {\n    policy round_robin\n    max_fails 2\n  }\n  prometheus :9153\n  loop\n  reload\n}\n"
+  }
+}'
+```
+
+### Step 5: Verify DNS Resolution
+
+```bash
+# Test from any pod
+kubectl run -it --rm test-dns --image=busybox --restart=Never -- \
+  nslookup google.com
+
+# Watch logs
+kubectl logs -n squawk deployment/dns-server -f
+
+# Check cache hit rate
+curl http://dns-server.squawk.svc.cluster.local:8080/metrics | grep cache_hits
+```
+
+## Stub Domain Configuration (Single Domain)
+
+If forwarding only specific domains to Squawk (not all upstream):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+      errors
+      health
+      ready
+      kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+      }
+      # Default upstream (Google)
+      forward . 8.8.8.8:53 8.8.4.4:53
+      prometheus :9153
+    }
+    
+    # Stub domain: special.example.com -> Squawk only
+    special.example.com:53 {
+      errors
+      forward . dns-client.squawk.svc.cluster.local:5300 {
+        policy round_robin
+      }
+    }
+```
+
+## Port Summary
+
+| Service | Port | Protocol | Purpose |
+|---------|------|----------|---------|
+| **dns-server** | 8080 | HTTP | DoH endpoint (`/dns-query`) |
+| **dns-client** | 5300 | UDP | Traditional DNS forwarding |
+| **manager** | 5000 | HTTP | Token issuance, admin API |
+| **manager** | 50051 | gRPC | Zone updates (internal) |
+
+## Troubleshooting
+
+### DNS Resolution Fails
+
+```bash
+# Check CoreDNS logs
+kubectl logs -n kube-system deployment/coredns
+
+# Verify Squawk dns-server is running
+kubectl get pods -n squawk
+kubectl logs -n squawk deployment/dns-server
+
+# Test direct connection
+kubectl run -it --rm test-conn --image=curlimages/curl --restart=Never -- \
+  curl -v http://dns-server.squawk.svc.cluster.local:8080/health
+
+# Check token validity
+kubectl get secret -n kube-system squawk-dns-token -o jsonpath='{.data.token}' | base64 -d | jq .
+```
+
+### Token Expired / 401 Errors
+
+```bash
+# Reissue token
+ADMIN_TOKEN=$(kubectl get secret -n squawk manager-admin-token -o jsonpath='{.data.token}' | base64 -d)
+
+NEW_TOKEN=$(curl -s -X POST http://manager.squawk.svc.cluster.local:5000/api/v1/tokens \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "coredns", "scopes": ["dns:query"]}' | jq -r .token)
+
+kubectl patch secret squawk-dns-token -n kube-system --type merge -p "{\"data\":{\"token\":\"$(echo $NEW_TOKEN | base64 -w0)\"}}"
+
+# Restart CoreDNS to pick up new token
+kubectl rollout restart deployment/coredns -n kube-system
+```
+
+### High Latency / Cache Misses
+
+- Verify Valkey is running: `kubectl logs -n squawk deployment/valkey`
+- Check dns-server replicas: `kubectl get pods -n squawk -l app.kubernetes.io/component=dns-server`
+- Scale up dns-server if cache hit rate is low: `kubectl scale deployment dns-server -n squawk --replicas=5`
+

--- a/docs/enterprise/DR-BACKUP.md
+++ b/docs/enterprise/DR-BACKUP.md
@@ -1,0 +1,231 @@
+# Disaster Recovery & Backup
+
+## Scope
+
+- **Manager PostgreSQL**: Token store, tenant configuration, DNS zones, DHCP pools, NTP settings
+- **Valkey**: Ephemeral cache only; loss is non-fatal (read below)
+- **DNS/DHCP/NTP state**: Ephemeral; rebuilt from configuration
+
+## PostgreSQL Backup & Restore
+
+### Backup via pg_dump
+
+```bash
+# Backup a running manager database
+pg_dump -h <postgres-host> -U <username> -d squawk_manager \
+  --format=custom --compress=9 \
+  --file=squawk-backup-$(date +%Y%m%d-%H%M%S).dump
+
+# From inside K8s (if DB is not on the same cluster, port-forward first)
+kubectl port-forward -n <postgres-namespace> <postgres-pod> 5432:5432 &
+pg_dump -h localhost -U postgres -d squawk_manager \
+  --format=custom --compress=9 \
+  --file=squawk-backup.dump
+```
+
+### Restore via pg_restore
+
+```bash
+# Restore to a fresh database
+createdb -h <postgres-host> -U <username> squawk_manager_restore
+pg_restore -h <postgres-host> -U <username> -d squawk_manager_restore \
+  --clean --if-exists squawk-backup.dump
+
+# Verify restoration
+psql -h <postgres-host> -U <username> -d squawk_manager_restore -c \
+  "SELECT COUNT(*) FROM tokens; SELECT COUNT(*) FROM zones;"
+
+# Once verified, cut over manager pods to the restored database
+# via updating the manager-db Secret (see K8s Restore below)
+```
+
+## Kubernetes CronJob Backup
+
+Deploy a nightly backup CronJob (adapt `<cluster>`, `<storage-class>`, `<retention-days>`):
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: squawk-backup
+  namespace: squawk
+spec:
+  schedule: "0 2 * * *"  # 2 AM UTC daily
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: squawk-backup
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+          containers:
+          - name: backup
+            image: postgres:17-bookworm@sha256:<digest>
+            env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: manager-db
+                  key: password
+            command:
+            - /bin/bash
+            - -c
+            - |
+              DB_URL=$(cat /etc/manager-db/url)
+              DB_HOST=$(echo $DB_URL | sed 's/.*@//;s/:.*//;s/\/.*//') 
+              DB_USER=$(echo $DB_URL | sed 's|.*://||;s/:.*//') 
+              DB_NAME=$(echo $DB_URL | sed 's|.*/||') 
+              pg_dump -h $DB_HOST -U $DB_USER -d $DB_NAME \
+                --format=custom --compress=9 \
+                --file=/backups/squawk-$(date +\%Y\%m\%d-\%H\%M\%S).dump
+              # Retain 7 days of backups
+              find /backups -maxdepth 1 -name "squawk-*.dump" \
+                -mtime +7 -delete
+            volumeMounts:
+            - name: manager-db
+              mountPath: /etc/manager-db
+              readOnly: true
+            - name: backup-storage
+              mountPath: /backups
+            resources:
+              requests:
+                cpu: 200m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+          restartPolicy: OnFailure
+          volumes:
+          - name: manager-db
+            secret:
+              secretName: manager-db
+          - name: backup-storage
+            persistentVolumeClaim:
+              claimName: squawk-backups
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: squawk-backups
+  namespace: squawk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: <storage-class>  # e.g., ebs-gp3, fast-ssd
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: squawk-backup
+  namespace: squawk
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: squawk-backup
+  namespace: squawk
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["manager-db"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: squawk-backup
+  namespace: squawk
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: squawk-backup
+subjects:
+- kind: ServiceAccount
+  name: squawk-backup
+  namespace: squawk
+```
+
+## Valkey Persistence Stance
+
+**Valkey in Squawk is ephemeral and cacheable.**
+
+Valkey stores:
+- DNS query result cache (TTL-managed)
+- Manager session state (transient)
+- Token verification cache (rebuilt on manager restart)
+
+**Why not persistent:** Loss of Valkey causes only temporary slowdown. Missing cache entries are fetched upstream or recomputed. Manager can rebuild its session state. All critical state (tokens, zones, pools) lives in PostgreSQL.
+
+**No RDB/AOF snapshots needed.** If cluster loss occurs:
+1. Restart manager pod → reconnects to PostgreSQL
+2. Restart dns-server pod → queries upstream without cache (slower, not broken)
+3. Cache rebuilds over minutes as queries arrive
+
+## Backup Retention & Cleanup
+
+- **Daily backups**: 7 days on-site PVC
+- **Weekly archives**: Move 1-week-old backups to object storage (S3, GCS, Blob) weekly via a separate Job
+- **Off-site retention**: 90 days minimum
+- **Test restores**: Monthly restore-drill on a staging database
+
+## RPO/RTO Table
+
+| Component | RPO (Max Data Loss) | RTO (Recovery Time) | Notes |
+|-----------|--------|---------|-------|
+| **Tokens** | Nightly backup (~24h) | 15-20 min (pg_restore + pod restart) | Stored in PostgreSQL only |
+| **Zones** | Nightly backup (~24h) | 15-20 min | DNS data in PostgreSQL |
+| **DHCP Pools** | Nightly backup (~24h) | 15-20 min | Lease state ephemeral |
+| **NTP Config** | Nightly backup (~24h) | 5 min (pod restart) | Config-driven, no state |
+| **Cache** | 0 (no persistence) | 0-5 min (cache rebuilt) | No data loss; performance impact only |
+
+**In-flight requests:** DNS/DHCP queries in-flight during outage are retried by clients. No loss of query history (not stored durably).
+
+## Restore-Drill Checklist
+
+**Monthly:** Verify backup integrity and restore procedures. Schedule outside business hours.
+
+- [ ] Download latest backup from PVC/object storage
+- [ ] Spin up a staging PostgreSQL instance (same major version)
+- [ ] Run `pg_restore` to a test database
+- [ ] Query test database: `SELECT COUNT(*) FROM tokens, zones, etc.`
+- [ ] Verify row counts match production baseline (document expected values)
+- [ ] Simulate manager restart against restored DB (deploy staging manager pod with restored DB_URL)
+- [ ] Verify manager health checks pass
+- [ ] Spot-check a few tokens: generate DNS query, verify token validation succeeds
+- [ ] Document restore time and any issues in ops log
+- [ ] Clean up test instances
+
+**Full disaster scenario:** Quarterly, restore to a clean K8s namespace and verify the entire stack:
+
+1. Restore manager database from backup
+2. Deploy manager, dns-server, dhcp-server, ntp-server against restored DB
+3. Issue test queries; verify responses correct
+4. Document full RTO
+
+## Off-Site Backup Archive
+
+```bash
+# Weekly archive script (add as a CronJob at 3 AM Sunday)
+#!/bin/bash
+WEEK=$(date +%G-W%V)
+aws s3 cp /backups/squawk-*.dump s3://<backup-bucket>/squawk/${WEEK}/ \
+  --sse AES256 --storage-class GLACIER
+find /backups -maxdepth 1 -name "squawk-*.dump" -mtime +7 -delete
+```
+
+Lifecycle policy on S3:
+- **Transition to GLACIER after 30 days**
+- **Delete after 90 days**
+

--- a/docs/enterprise/HA-DEPLOYMENT.md
+++ b/docs/enterprise/HA-DEPLOYMENT.md
@@ -1,0 +1,322 @@
+# High Availability Deployment
+
+## Service Replicas
+
+Current Helm defaults (chart values.yaml):
+
+| Service | Replicas | Persistence | Notes |
+|---------|----------|-------------|-------|
+| **manager** | 1 | PostgreSQL external | Singleton; single leader only |
+| **dns-server** | 2 | Valkey cache | Stateless; scale horizontally |
+| **dhcp-server** | 3 | Valkey state | Stateless; replicas share pool |
+| **ntp-server** | 3 | None | Stateless |
+| **valkey** | 1 | In-memory | Cache; ephemeral |
+
+**Production recommendation:**
+- `dns-server`: 3+ replicas minimum for quorum-based failover
+- `dhcp-server`: 3+ replicas (odd number prevents split-brain on DHCP state)
+- `ntp-server`: 3+ replicas (NTP requires 3+ peers for clock discipline)
+- `manager`: 1 (scaling to 2+ requires distributed consensus, not yet implemented)
+- `valkey`: 1 or 3 (if high cache hit rate expected, use Valkey Cluster for HA)
+
+## Pod Disruption Budget (PDB)
+
+PDB support is coming in a parallel chart update. Use template below to enforce minimum availability during cluster maintenance:
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dns-server-pdb
+  namespace: squawk
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: squawk
+      app.kubernetes.io/component: dns-server
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dhcp-server-pdb
+  namespace: squawk
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: squawk
+      app.kubernetes.io/component: dhcp-server
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ntp-server-pdb
+  namespace: squawk
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: squawk
+      app.kubernetes.io/component: ntp-server
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: valkey-pdb
+  namespace: squawk
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: squawk
+      app.kubernetes.io/component: cache
+```
+
+## Horizontal Pod Autoscaler (HPA)
+
+HPA support is coming in a parallel chart update. Use template for CPU/memory-driven scaling:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: dns-server-hpa
+  namespace: squawk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: dns-server
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 75
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 15
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 25
+        periodSeconds: 60
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: dhcp-server-hpa
+  namespace: squawk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: dhcp-server
+  minReplicas: 3
+  maxReplicas: 20
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 75
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 45
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 15
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+```
+
+## DNS Data-Plane Horizontal Scaling
+
+### Multiple Replicas Behind Service
+
+All dns-server replicas expose the same `/dns-query` endpoint on port 8080. K8s Service round-robins:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-server
+  namespace: squawk
+spec:
+  type: ClusterIP
+  sessionAffinity: None  # Round-robin load balancing
+  ports:
+  - name: doh
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: squawk
+    app.kubernetes.io/component: dns-server
+```
+
+Clients (k8s-dns, dns-client, external) query `http://dns-server.squawk.svc.cluster.local:8080/dns-query`.
+
+**Query behavior:**
+- Each replica caches independently (no shared cache between dns-server pods)
+- Cache hit rate ~60-80% per pod on typical workloads
+- On replica failure, in-flight queries retry to surviving replicas within seconds
+
+### Multi-Region / Anycast DoH Deployment
+
+For geographic distribution, deploy Squawk to multiple K8s clusters with shared upstream PostgreSQL:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Cluster A (us-west-2)                               │
+│  dns-server (3x)  ──────────────────┐                │
+│  dhcp-server (3x) ────────────────┐  │                │
+│  manager (1x)  ────────────┐       │  │                │
+└──────────────────────┬──────────────┼──┼────────────────┘
+                       │      ↓       ↓  ↓
+┌──────────────────────┼──────────────────────────────┐
+│ PostgreSQL (managed service, multi-AZ replication)  │
+│ - eu-west-1 primary                                 │
+│ - us-west-2 replica (read-only for dns-server)      │
+└──────────────────────────────────────────────────────┘
+                       ↑
+┌──────────────────────┼──────────────────────────────┐
+│ Cluster B (eu-west-1)                                │
+│  dns-server (3x)  ───────────────┐                   │
+│  dhcp-server (3x) ──────────────┐ │                   │
+│  manager (1x) ────────────┐      │ │                   │
+└──────────────────────┬────────────┼─────────────────────┘
+                       └─→ Primary DB
+```
+
+**Anycast ingress:**
+- Both regions serve DoH at `dns.example.com` (separate Ingress per cluster)
+- Client resolves `dns.example.com` → nearest region via Geo-DNS or GeoIP-based Anycast
+- Each region's dns-server replicas share a local Valkey cache
+- DHCP state: Replicas in both regions can serve (active/active) or primary region only (active/passive)
+
+**Manager deployment:**
+- Primary cluster (eu-west-1): Active manager, writes to PostgreSQL primary
+- Secondary cluster (us-west-2): Standby manager (optional, not serving requests) or offline
+
+**Failover:**
+- If primary region fails, secondary becomes primary (update manager, DNS entries)
+- PostgreSQL failover: managed by RDS/Cloud SQL multi-AZ replication or external tool (e.g., Patroni)
+
+## NTP HA Notes
+
+NTP (SNTP in Squawk) runs on port 11123 (UDP). For HA:
+
+- **3+ replicas minimum** (NTP clock discipline requires 3+ sources)
+- Deploy to separate nodes if possible (`podAntiAffinity: preferred`)
+- Each replica independently serves time (no shared state)
+- Clients (time.example.com) resolves to all 3 replicas via SRV records or simple A record + client-side retry
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ntp-server
+  namespace: squawk
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless for direct pod access
+  ports:
+  - name: ntp
+    port: 11123
+    targetPort: 11123
+    protocol: UDP
+  selector:
+    app.kubernetes.io/name: squawk
+    app.kubernetes.io/component: ntp-server
+---
+apiVersion: policy/v1
+kind: PodAntiAffinity
+metadata:
+  name: ntp-server-anti-affinity
+spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values: [ntp-server]
+          topologyKey: kubernetes.io/hostname
+```
+
+## DHCP HA: Lease State & Failover
+
+DHCP is stateful: client leases must persist across failover to avoid duplicate IPs.
+
+**Active/Passive (single primary):**
+- One DHCP replica (pod) serves all clients
+- Others standby
+- Shared Valkey stores lease state
+- On primary failure: Secondary pod takes over, queries Valkey, resumes serving leases
+- **Loss of Valkey = loss of lease state** (client conflict recovery via DHCP conflict detection)
+
+**Lease recovery after Valkey loss:**
+- Clients retry DHCP DISCOVER (no lease = new assignment)
+- Old lease binding times out (default ~24h based on LEASE_TIME env var)
+- Duplicate prevention: DHCP servers check for conflicts via ARP
+
+**Active/Active (not currently supported):**
+- Multiple DHCP replicas assign from disjoint pool ranges
+- Pool subnet partitioning (Replica A: 192.168.1.100-150, Replica B: 192.168.1.151-200)
+- Requires non-overlapping pool config per replica
+- **Current deployment uses shared pool (Active/Passive recommended)**
+
+**Recommendation:** Deploy 3 DHCP replicas with `minAvailable: 1` PDB. Valkey must be highly available (Valkey Cluster or Redis Cluster if planning Active/Active).
+
+## Valkey HA (Optional)
+
+For production high-cache-hit workloads, upgrade Valkey to a cluster:
+
+```yaml
+# Enable via chart update (parallel branch)
+valkey:
+  cluster:
+    enabled: true
+    nodes: 6  # 3 masters + 3 replicas
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+```
+
+Alternative: Managed Redis/Valkey (AWS ElastiCache, GCP Memorystore, Azure Cache) auto-handles HA.
+

--- a/docs/enterprise/README.md
+++ b/docs/enterprise/README.md
@@ -1,0 +1,60 @@
+# Enterprise Operations Guides
+
+Comprehensive guides for operating Squawk in production environments.
+
+## Contents
+
+### [DR-BACKUP.md](DR-BACKUP.md) — Disaster Recovery & Backup
+- PostgreSQL backup via `pg_dump` and restoration
+- Kubernetes CronJob backup manifest with retention policies
+- Valkey persistence stance (ephemeral cache, no persistence needed)
+- RPO/RTO table per component (tokens, zones, cache)
+- Monthly restore-drill checklist and off-site archival
+
+### [HA-DEPLOYMENT.md](HA-DEPLOYMENT.md) — High Availability Deployment
+- Replica counts per service (dns-server 3+, dhcp-server 3+, ntp-server 3+)
+- Pod Disruption Budget (PDB) and Horizontal Pod Autoscaler (HPA) templates
+- DNS data-plane horizontal scaling behind K8s Service
+- Multi-region/anycast DoH deployment patterns with shared PostgreSQL
+- NTP HA (3+ replicas required for clock discipline)
+- DHCP HA caveats: active/passive recommended, lease state persistence via Valkey
+- Valkey cluster upgrade path for high cache-hit workloads
+
+### [SUPPLY-CHAIN-VERIFICATION.md](SUPPLY-CHAIN-VERIFICATION.md) — Supply Chain Verification
+- Image signing details: cosign keyless + GitHub OIDC
+- Verifying image signatures with `cosign verify`
+- Inspecting SBOM attestations and scanning for vulnerabilities
+- Kyverno ClusterPolicy template for admission-time signature enforcement
+- Dependency scanning with Grype, Snyk, OSV
+- Monthly supply chain audit checklist
+
+### [COREDNS-INTEGRATION.md](COREDNS-INTEGRATION.md) — CoreDNS Integration
+- Squawk as an upstream resolver for in-cluster DNS
+- CoreDNS ConfigMap examples (Option A: via dns-client sidecar, Option B: direct DoH)
+- JWT authentication setup for CoreDNS → Squawk forwarding
+- Stub domain configuration (single domain forwarding)
+- Port reference table (DoH 8080, UDP 5300, API 5000)
+- Troubleshooting guide: resolution failures, token expiry, latency
+
+## Quick Start
+
+For a production deployment:
+
+1. **Backup:** Set up the CronJob from [DR-BACKUP.md](DR-BACKUP.md) immediately
+2. **HA:** Deploy 3+ replicas per service using PDB templates in [HA-DEPLOYMENT.md](HA-DEPLOYMENT.md)
+3. **Verification:** Enforce image signatures via Kyverno policy in [SUPPLY-CHAIN-VERIFICATION.md](SUPPLY-CHAIN-VERIFICATION.md)
+4. **Integration:** If using CoreDNS, forward via [COREDNS-INTEGRATION.md](COREDNS-INTEGRATION.md)
+
+## Environments
+
+These guides apply to:
+- **Beta** (`dal2-beta`): Test HA/DR procedures
+- **Gamma** (`dal2-gamma`): Staging supply chain verification
+- **Production** (`{repo}-prod`): Full enforcement of all practices
+
+## See Also
+
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md) — System architecture and design
+- [docs/DEVELOPMENT.md](../DEVELOPMENT.md) — Local development setup
+- [docs/TESTING.md](../TESTING.md) — Testing practices
+

--- a/docs/enterprise/SUPPLY-CHAIN-VERIFICATION.md
+++ b/docs/enterprise/SUPPLY-CHAIN-VERIFICATION.md
@@ -1,0 +1,247 @@
+# Supply Chain Verification
+
+Squawk images are signed with cosign using GitHub OIDC (keyless) and include SPDX SBOM attestations. This guide covers verification and enforcement.
+
+## Image Signing
+
+Every Squawk image pushed to ghcr.io/penguintechinc/squawk is signed by CI/CD (see `.github/workflows/push.yml`):
+
+```bash
+# CI signing (automated)
+cosign sign --yes ghcr.io/penguintechinc/squawk@sha256:<digest>
+cosign attest --yes --predicate sbom-server.spdx.json --type spdxjson \
+  ghcr.io/penguintechinc/squawk@sha256:<digest>
+```
+
+**Signing identity:** GitHub Actions workflow in penguintechinc/squawk repository, using the OIDC token issued by GitHub.
+
+## Verifying Image Signatures
+
+### Prerequisites
+
+```bash
+# Install cosign
+curl -sLo /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/download/v2.x.x/cosign-linux-amd64
+chmod +x /usr/local/bin/cosign
+
+# Install syft (for SBOM inspection)
+curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+```
+
+### Verify Signature
+
+```bash
+# Verify signature using GitHub OIDC identity
+cosign verify \
+  --certificate-identity https://github.com/penguintechinc/squawk/.github/workflows/push.yml@refs/heads/v1.0.x \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/penguintechinc/squawk:v1.0.0
+
+# Output (signature valid)
+Verification successful!
+```
+
+**Certificate identity breakdown:**
+- **Workflow file:** `.github/workflows/push.yml` (exact workflow signing the image)
+- **Branch/ref:** `refs/heads/v1.0.x` (release branch) or `refs/heads/main` (gamma builds)
+- **OIDC issuer:** GitHub Actions token issuer
+
+### Inspect SBOM Attestation
+
+```bash
+# Download and inspect SBOM
+cosign download attestation \
+  --attestation-type spdxjson \
+  ghcr.io/penguintechinc/squawk:v1.0.0 > sbom.spdx.json
+
+# Verify SBOM is signed
+cosign verify-attestation \
+  --certificate-identity https://github.com/penguintechinc/squawk/.github/workflows/push.yml@refs/heads/v1.0.x \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --attestation-type spdxjson \
+  ghcr.io/penguintechinc/squawk:v1.0.0 | jq '.payload | @base64d | fromjson'
+
+# Inspect SBOM contents (check dependencies, licenses)
+syft /tmp/sbom.spdx.json
+# Or parse raw SBOM:
+jq '.components[] | "\(.name):\(.version)"' sbom.spdx.json
+```
+
+## Kyverno ClusterPolicy for Image Signature Verification
+
+Deploy this Kyverno policy to enforce signature verification at admission time. Adapt the certificate identity and branch names for your deployment:
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-squawk-image-signatures
+spec:
+  validationFailureAction: audit  # Change to 'enforce' once validated in your cluster
+  webhookTimeoutSeconds: 30
+  failurePolicy: fail
+  rules:
+  - name: check-squawk-signature
+    match:
+      resources:
+        kinds:
+        - Pod
+        - Deployment
+        - StatefulSet
+        - DaemonSet
+        - Job
+        - CronJob
+    verifyImages:
+    - imageReferences:
+      - ghcr.io/penguintechinc/squawk*
+      - ghcr.io/penguintechinc/squawk-dns-client*
+      - ghcr.io/penguintechinc/squawk-k8s-dns*
+      attestations:
+      - name: spdxjson
+        attestationPattern: |
+          (predicateType == "https://spdx.dev/Document/spdx-v2.3.json")
+      - name: sbom-check
+        conditions:
+        - all:
+          - key: "{{ attestation.spdxjson.components[].name }}"
+            operator: AnyNotIn
+            value:
+            - vulnerable-dependency-name  # Add known bad dependencies here
+      verifySignature:
+        keyless:
+          signatureFormat: cosign
+          provider: github
+          identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/penguintechinc/squawk/.github/workflows/push.yml@refs/heads/v1.0.x
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/penguintechinc/squawk/.github/workflows/push.yml@refs/heads/main
+      mutateDigest: true
+      mutateImage: true
+  - name: audit-unsigned
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "Unsigned Squawk images must be reviewed and tested before deployment"
+      pattern:
+        spec:
+          containers:
+          - image: ghcr.io/penguintechinc/squawk*
+            |(image): '?@ ?# Image lacks signature verification'
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: squawk
+  labels:
+    # Label to enable policy (optional)
+    pod-security.kubernetes.io/enforce: baseline
+---
+# Bind policy to squawk namespace (optional; by default applies cluster-wide)
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-squawk-image-signatures-ns-bound
+spec:
+  validationFailureAction: audit
+  rules:
+  - name: check-squawk-signature-ns
+    match:
+      resources:
+        kinds:
+        - Pod
+        namespaceSelector:
+          matchLabels:
+            pod-security.kubernetes.io/enforce: baseline
+    verifyImages:
+    - imageReferences:
+      - ghcr.io/penguintechinc/squawk*
+      verifySignature:
+        keyless:
+          signatureFormat: cosign
+          provider: github
+          identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/penguintechinc/squawk/.github/workflows/push.yml@refs/heads/v*.*.x
+```
+
+## Deployment Steps
+
+1. **Install Kyverno** (if not already present):
+
+```bash
+kubectl apply -f https://github.com/kyverno/kyverno/releases/download/v1.12.0/install.yaml
+```
+
+2. **Deploy the policy**:
+
+```bash
+kubectl apply -f verify-squawk-images-policy.yaml
+```
+
+3. **Validate policy works**:
+
+```bash
+# Test with an unsigned image (should audit/fail)
+kubectl run test-unsigned --image=ghcr.io/penguintechinc/squawk:latest -n squawk
+# Verify event logged:
+kubectl describe pod test-unsigned -n squawk | grep -i kyverno
+
+# Clean up test
+kubectl delete pod test-unsigned -n squawk
+```
+
+4. **Switch to enforcement** (after validation):
+
+```bash
+kubectl patch clusterpolicy verify-squawk-image-signatures \
+  --type='json' -p='[{"op": "replace", "path": "/spec/validationFailureAction", "value":"enforce"}]'
+```
+
+## SBOM Dependency Scanning
+
+Squawk's SBOM includes all dependencies (Go modules, system libraries). Integrate with vulnerability scanners:
+
+```bash
+# Using Anchore Grype (local scanning)
+grype sbom.spdx.json --fail-on high
+
+# Using Snyk (cloud-based)
+snyk sbom --file sbom.spdx.json
+
+# Using OSV (Google open-source scanner)
+osv-scanner --sbom sbom.spdx.json
+```
+
+Add to your CI/CD:
+
+```yaml
+# GitHub Actions example
+- name: Scan SBOM for vulnerabilities
+  uses: anchore/scan-action@v4
+  with:
+    sbom: sbom.spdx.json
+    fail-build: true
+    severity-cutoff: high
+```
+
+## Policies & Audit Log
+
+- **All unsigned images**: Logged as audit events in Kyverno; optionally blocked
+- **Signed images from unknown workflows**: Blocked at admission
+- **Signed images with vulnerable dependencies (SBOM check)**: Audit or block based on policy
+- **Audit log location**: `kubectl logs -n kyverno deployment/kyverno`
+
+## Testing Supply Chain
+
+**Monthly:** Verify signature chain end-to-end:
+
+1. Pull latest release image
+2. Verify signature: `cosign verify --certificate-identity=... ghcr.io/penguintechinc/squawk:v1.0.X`
+3. Download SBOM: `cosign download attestation --attestation-type spdxjson ghcr.io/...`
+4. Scan SBOM: `grype sbom.spdx.json --fail-on high`
+5. Deploy to staging: Verify Kyverno allows it (signature + SBOM check pass)
+6. Document findings
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ graph TB
 | [Contributing](CONTRIBUTING.md) | Development and contribution guidelines |
 | [Development Setup](DEVELOPMENT.md) | Local development environment setup |
 | [Release Notes](RELEASE_NOTES.md) | Latest features and changes |
+| [Enterprise Operations](enterprise/README.md) | DR, HA, supply chain verification, CoreDNS integration |
 
 ## Support & Community
 


### PR DESCRIPTION
Four enterprise operator guides under docs/enterprise/ — DR-BACKUP (pg_dump/restore, CronJob manifest, RPO/RTO table, restore drill), HA-DEPLOYMENT (per-service replica guidance, multi-region/anycast DoH patterns, DHCP active/passive caveats), SUPPLY-CHAIN-VERIFICATION (cosign keyless verify against the CI OIDC identity, SBOM retrieval, Kyverno verifyImages template), COREDNS-INTEGRATION (forward/stub-domain configs against the chart's actual service ports) — plus index. All values/ports/commands verified against the Helm chart and push.yml; environment-specific bits marked as placeholders.
---
**Stack note:** bases on `chore/dedup-reusable-code` (top of the #53–#59 chain); auto-retargets toward `v2.1.x` as the stack merges bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
