### PR TITLE
[Chore] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for penguintechinc/squawk
+#
+# The org default-branch ruleset sets require_code_owner_review, so every PR
+# into the default branch needs an approving review from someone listed here.
+#
+# Two owners deliberately. GitHub forbids approving your own PR, so a single
+# owner who also writes most of the PRs would make every one of them
+# unmergeable except by admin bypass — which would defeat the review
+# requirement rather than satisfy it.
+
+*   @PenguinzTech @Chromeninja


### PR DESCRIPTION
## Summary

The org default-branch ruleset sets `require_code_owner_review`, so every PR into `main` needs an approving review from someone listed in CODEOWNERS. This repo has no CODEOWNERS file, meaning that requirement currently matches nobody — making every PR unmergeable without an admin bypass.

This PR adds `.github/CODEOWNERS` with:

```
*   @PenguinzTech @Chromeninja
```

Two owners are listed deliberately: GitHub forbids approving your own PR, so a single owner who also authors most PRs would make their own PRs permanently unmergeable except via admin bypass.

## Summary by Sourcery

Chores:
- Introduce .github/CODEOWNERS assigning ownership of all files to the designated maintainers.