### PR TITLE
fix(manager): RedisStorage expects a client instance, not a URL string

### DIFF
--- a/manager/backend/app/__init__.py
+++ b/manager/backend/app/__init__.py
@@ -59,8 +59,9 @@ def create_app(config_class: type = Config) -> Flask:
     _storage_url = app.config.get("RATELIMIT_STORAGE_URL")
 
     if _storage_url:
+        import redis
         from penguin_limiter.storage.redis_store import RedisStorage
-        _storage = RedisStorage(url=_storage_url)
+        _storage = RedisStorage(client=redis.Redis.from_url(_storage_url))
     else:
         _storage = MemoryStorage()
 


### PR DESCRIPTION
## Summary

Verifying manager's Dockerfile end-to-end now that `penguin-limiter` is published on PyPI (was previously missing entirely, blocking any build). The image now builds cleanly, but `create_app()` crashed at boot:

```
TypeError: RedisStorage.__init__() got an unexpected keyword argument 'url'
```

`penguin_limiter.storage.redis_store.RedisStorage.__init__(self, client, key_prefix=...)` takes an already-constructed redis-py client (it calls `client.register_script(...)` internally) — not a connection URL string. Manager called `RedisStorage(url=_storage_url)`. This is the first time this code path has ever actually run, since the package didn't exist until this week.

## Fix

Construct the redis-py client first, pass that:

```python
_storage = RedisStorage(client=redis.Redis.from_url(_storage_url))
```

## Verification

- Built the real `manager/backend/Dockerfile` end-to-end (no stripped dependencies)
- Confirmed `penguin-limiter` resolves and installs from PyPI
- Ran the container via its actual entrypoint (gunicorn, not just an import check) against a live Valkey instance
- All 4 gunicorn workers boot; `curl /health` returns `{"status":"healthy"}` with HTTP 200; container stays up

## Test plan

- [x] `docker build` succeeds
- [x] Container runs via real entrypoint against live Valkey
- [x] `/health` returns 200
- [x] Pre-commit hooks (gitleaks, flake8, Dockerfile lint) pass